### PR TITLE
refactor: centralize tlwh/xyah box conversions in utils::geometry

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("README.md")]
 
-use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
+use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
+use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
 
 // Define STrack
 /// A Single Track (STrack) representing a tracked object.
@@ -65,7 +66,7 @@ impl STrack {
         self.track_id = track_id;
         self.tracklet_len = 0;
 
-        let measurement = self.tlwh_to_xyah(self.tlwh);
+        let measurement = tlwh_to_xyah(&self.tlwh);
         let (mean, covariance) = kf.initiate(&measurement);
         self.mean = mean;
         self.covariance = covariance;
@@ -78,7 +79,7 @@ impl STrack {
         new_track_id: Option<u64>,
         kf: &KalmanFilter,
     ) {
-        let measurement = self.tlwh_to_xyah(new_track.tlwh);
+        let measurement = tlwh_to_xyah(&new_track.tlwh);
         let (mean, covariance) = kf.update(&self.mean, &self.covariance, &measurement);
         self.mean = mean;
         self.covariance = covariance;
@@ -103,7 +104,7 @@ impl STrack {
         self.score = new_track.score;
         self.tlwh = new_track.tlwh;
 
-        let measurement = self.tlwh_to_xyah(new_track.tlwh);
+        let measurement = tlwh_to_xyah(&new_track.tlwh);
         let (mean, covariance) = kf.update(&self.mean, &self.covariance, &measurement);
         self.mean = mean;
         self.covariance = covariance;
@@ -116,24 +117,8 @@ impl STrack {
         let (mean, covariance) = kf.predict(&self.mean, &self.covariance);
         self.mean = mean;
         self.covariance = covariance;
-        let tlwh = self.tlwh_from_xyah(&self.mean);
+        let tlwh = xyah_to_tlwh(&self.mean);
         self.tlwh = tlwh; // Update box estimate
-    }
-
-    fn tlwh_to_xyah(&self, tlwh: [f32; 4]) -> MeasurementVector {
-        let x = tlwh[0] + tlwh[2] / 2.0;
-        let y = tlwh[1] + tlwh[3] / 2.0;
-        let a = tlwh[2] / tlwh[3];
-        let h = tlwh[3];
-        MeasurementVector::from_vec(vec![x, y, a, h])
-    }
-
-    fn tlwh_from_xyah(&self, xyah: &StateVector) -> [f32; 4] {
-        let w = xyah[2] * xyah[3];
-        let h = xyah[3];
-        let x = xyah[0] - w / 2.0;
-        let y = xyah[1] - h / 2.0;
-        [x, y, w, h]
     }
 }
 

--- a/src/trackers/deepsort/track.rs
+++ b/src/trackers/deepsort/track.rs
@@ -69,20 +69,12 @@ impl Track {
 
     /// Convert TLWH to (x, y, a, h)
     pub fn tlwh_to_xyah(tlwh: &[f32; 4]) -> MeasurementVector {
-        let x = tlwh[0] + tlwh[2] / 2.0;
-        let y = tlwh[1] + tlwh[3] / 2.0;
-        let a = tlwh[2] / tlwh[3].max(1e-6);
-        let h = tlwh[3];
-        MeasurementVector::from_vec(vec![x, y, a, h])
+        crate::utils::geometry::tlwh_to_xyah(tlwh)
     }
 
     /// Convert (x, y, a, h) to TLWH
     pub fn xyah_to_tlwh(state: &StateVector) -> [f32; 4] {
-        let w = state[2] * state[3];
-        let h = state[3];
-        let x = state[0] - w / 2.0;
-        let y = state[1] - h / 2.0;
-        [x, y, w, h]
+        crate::utils::geometry::xyah_to_tlwh(state)
     }
 
     pub fn to_tlwh(&self) -> [f32; 4] {

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("README.md")]
 
+use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
 use std::collections::HashSet;
 
@@ -150,8 +151,8 @@ impl OcSortTrack {
         }
 
         // Interpolate in TLWH space (reference interpolates in (x,y,w,h), not xyah).
-        let last_tlwh = xyah4_to_tlwh(last_obs);
-        let current_tlwh = xyah4_to_tlwh(current_xyah);
+        let last_tlwh = xyah_to_tlwh(last_obs);
+        let current_tlwh = xyah_to_tlwh(current_xyah);
 
         let (mut mean, mut covariance) = kf.initiate(last_obs);
 
@@ -192,35 +193,6 @@ impl OcSortTrack {
     fn is_confirmed(&self) -> bool {
         self.state == OcSortTrackState::Confirmed
     }
-}
-
-// ---------------------------------------------------------------------------
-// Coordinate helpers
-// ---------------------------------------------------------------------------
-
-fn tlwh_to_xyah(tlwh: &[f32; 4]) -> MeasurementVector {
-    let cx = tlwh[0] + tlwh[2] / 2.0;
-    let cy = tlwh[1] + tlwh[3] / 2.0;
-    let a = tlwh[2] / tlwh[3].max(1e-6);
-    let h = tlwh[3];
-    MeasurementVector::from_vec(vec![cx, cy, a, h])
-}
-
-fn xyah_to_tlwh(state: &StateVector) -> [f32; 4] {
-    let w = state[2] * state[3];
-    let h = state[3];
-    let x = state[0] - w / 2.0;
-    let y = state[1] - h / 2.0;
-    [x, y, w, h]
-}
-
-/// Convert a 4-element xyah measurement vector (cx, cy, aspect, height) to TLWH.
-fn xyah4_to_tlwh(xyah: &MeasurementVector) -> [f32; 4] {
-    let w = xyah[2] * xyah[3];
-    let h = xyah[3];
-    let x = xyah[0] - w / 2.0;
-    let y = xyah[1] - h / 2.0;
-    [x, y, w, h]
 }
 
 // ---------------------------------------------------------------------------
@@ -488,7 +460,7 @@ impl OcSort {
             let left_trk_obs: Vec<[f32; 4]> = unmatched_trks
                 .iter()
                 .map(|&ti| {
-                    xyah4_to_tlwh(
+                    xyah_to_tlwh(
                         &self.tracks[ti]
                             .observations
                             .last()

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("README.md")]
 
-use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
+use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
+use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
 use std::collections::HashSet;
 
 /// Track state enumeration for SORT.
@@ -48,7 +49,7 @@ impl SortTrack {
         kf: &KalmanFilter,
         track_id: u64,
     ) -> Self {
-        let measurement = Self::tlwh_to_xyah(&tlwh);
+        let measurement = tlwh_to_xyah(&tlwh);
         let (mean, covariance) = kf.initiate(&measurement);
 
         Self {
@@ -74,12 +75,12 @@ impl SortTrack {
         self.time_since_update += 1;
 
         // Update tlwh from predicted state
-        self.tlwh = Self::xyah_to_tlwh(&self.mean);
+        self.tlwh = xyah_to_tlwh(&self.mean);
     }
 
     /// Update the track with a matched detection.
     fn update(&mut self, detection: &Detection, kf: &KalmanFilter) {
-        let measurement = Self::tlwh_to_xyah(&detection.tlwh);
+        let measurement = tlwh_to_xyah(&detection.tlwh);
         let (mean, covariance) = kf.update(&self.mean, &self.covariance, &measurement);
         self.mean = mean;
         self.covariance = covariance;
@@ -99,22 +100,6 @@ impl SortTrack {
     /// Check if track should be confirmed based on min_hits.
     pub fn is_confirmed(&self) -> bool {
         self.state == SortTrackState::Confirmed
-    }
-
-    fn tlwh_to_xyah(tlwh: &[f32; 4]) -> MeasurementVector {
-        let x = tlwh[0] + tlwh[2] / 2.0;
-        let y = tlwh[1] + tlwh[3] / 2.0;
-        let a = tlwh[2] / tlwh[3].max(1e-6);
-        let h = tlwh[3];
-        MeasurementVector::from_vec(vec![x, y, a, h])
-    }
-
-    fn xyah_to_tlwh(state: &StateVector) -> [f32; 4] {
-        let w = state[2] * state[3];
-        let h = state[3];
-        let x = state[0] - w / 2.0;
-        let y = state[1] - h / 2.0;
-        [x, y, w, h]
     }
 }
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -1,3 +1,29 @@
+use crate::utils::kalman::MeasurementVector;
+use nalgebra::SVector;
+
+/// Convert a bounding box from TLWH to XYAH (center-x, center-y, aspect ratio, height).
+///
+/// The aspect ratio is `width / height`, guarded against division by zero.
+pub fn tlwh_to_xyah(tlwh: &[f32; 4]) -> MeasurementVector {
+    let x = tlwh[0] + tlwh[2] / 2.0;
+    let y = tlwh[1] + tlwh[3] / 2.0;
+    let a = tlwh[2] / tlwh[3].max(1e-6);
+    let h = tlwh[3];
+    MeasurementVector::from_vec(vec![x, y, a, h])
+}
+
+/// Convert an XYAH vector back to a TLWH bounding box.
+///
+/// Accepts any vector with at least four components (e.g. the 8-dim Kalman state
+/// or the 4-dim measurement vector); only the first four elements are used.
+pub fn xyah_to_tlwh<const N: usize>(state: &SVector<f32, N>) -> [f32; 4] {
+    let w = state[2] * state[3];
+    let h = state[3];
+    let x = state[0] - w / 2.0;
+    let y = state[1] - h / 2.0;
+    [x, y, w, h]
+}
+
 /// Calculate Intersection over Union (IoU) between two bounding boxes.
 ///
 /// # Arguments


### PR DESCRIPTION
## Summary

The four trackers (SORT, OC-SORT, ByteTrack, DeepSORT) each carried private copies of `tlwh_to_xyah` and `xyah_to_tlwh`. This moves them into `utils::geometry` as shared functions.

- `xyah_to_tlwh` is generic over vector dimension, so it covers both the 8-dim Kalman state and the 4-dim measurement vector. This also subsumes OC-SORT's separate `xyah4_to_tlwh` helper.
- SORT, OC-SORT and ByteTrack drop their local copies and call the shared functions. ByteTrack now gains the divide-by-zero guard the others already had.
- DeepSORT keeps its public `Track::tlwh_to_xyah` and `Track::xyah_to_tlwh` as thin delegators, so the public API is unchanged.

No behavioral change. All tests pass; clippy clean on default and the `python` feature.

## Stack

This is the base of a three-PR stack. Merge bottom to top:
1. this PR
2. refactor: share greedy assignment core in utils::assignment
3. refactor: share DeepSORT tracker construction across Rust and Python