### PR TITLE
refactor: share greedy assignment core in utils::assignment

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -394,49 +394,16 @@ impl ByteTrack {
         )
     }
 
+    /// Greedy linear assignment.
+    ///
+    /// Rows are tracks and columns are detections; returns matches as
+    /// `(track, detection)` pairs alongside the unmatched tracks and detections.
     fn linear_assignment(
         &self,
         cost_matrix: &[Vec<f32>],
         thresh: f32,
     ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-        use std::collections::HashSet;
-
-        if cost_matrix.is_empty() {
-            return (Vec::new(), Vec::new(), Vec::new());
-        }
-
-        let rows = cost_matrix.len();
-        let cols = cost_matrix[0].len();
-
-        // Greedy matching
-        let mut matches = Vec::new();
-        let mut unmatched_tracks = (0..rows).collect::<HashSet<_>>();
-        let mut unmatched_detections = (0..cols).collect::<HashSet<_>>();
-
-        let mut costs = Vec::new();
-        for (r, row) in cost_matrix.iter().enumerate() {
-            for (c, &cost) in row.iter().enumerate() {
-                costs.push((cost, r, c));
-            }
-        }
-        // sort by cost
-        costs.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-        for (cost, r, c) in costs {
-            if cost > thresh {
-                continue;
-            }
-            if unmatched_tracks.contains(&r) && unmatched_detections.contains(&c) {
-                matches.push((r, c));
-                unmatched_tracks.remove(&r);
-                unmatched_detections.remove(&c);
-            }
-        }
-
-        let u_track: Vec<usize> = unmatched_tracks.into_iter().collect();
-        let u_det: Vec<usize> = unmatched_detections.into_iter().collect();
-
-        (matches, u_track, u_det)
+        crate::utils::assignment::greedy_match(cost_matrix, thresh)
     }
 }
 

--- a/src/trackers/deepsort/tracker.rs
+++ b/src/trackers/deepsort/tracker.rs
@@ -306,46 +306,15 @@ impl DeepSortTracker {
 }
 
 /// Simple greedy min cost matching (Linear Assignment Problem).
+/// Greedy linear assignment over a cost matrix.
+///
+/// Rows are tracks and columns are detections; returns matches as `(row, col)`
+/// pairs alongside the unmatched rows and columns.
 fn min_cost_matching(
     cost_matrix: &[Vec<f32>],
     threshold: f32,
 ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-    if cost_matrix.is_empty() {
-        return (Vec::new(), Vec::new(), Vec::new());
-    }
-
-    let rows = cost_matrix.len();
-    let cols = cost_matrix[0].len();
-
-    let mut matches = Vec::new();
-    let mut unmatched_rows: HashSet<usize> = (0..rows).collect();
-    let mut unmatched_cols: HashSet<usize> = (0..cols).collect();
-
-    let mut costs = Vec::new();
-    for (r, row) in cost_matrix.iter().enumerate() {
-        for (c, &cost) in row.iter().enumerate() {
-            costs.push((cost, r, c));
-        }
-    }
-
-    costs.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-    for (cost, r, c) in costs {
-        if cost > threshold {
-            continue;
-        }
-        if unmatched_rows.contains(&r) && unmatched_cols.contains(&c) {
-            matches.push((r, c));
-            unmatched_rows.remove(&r);
-            unmatched_cols.remove(&c);
-        }
-    }
-
-    (
-        matches,
-        unmatched_rows.into_iter().collect(),
-        unmatched_cols.into_iter().collect(),
-    )
+    crate::utils::assignment::greedy_match(cost_matrix, threshold)
 }
 
 #[cfg(test)]

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -507,45 +507,18 @@ impl Default for OcSort {
 // Greedy matching
 // ---------------------------------------------------------------------------
 
+/// Greedy assignment for OC-SORT.
+///
+/// Rows are tracks and columns are detections; returns matches as
+/// `(detection, track)` pairs alongside the unmatched detections and tracks.
 fn greedy_match(
     cost_matrix: &[Vec<f32>],
     threshold: f32,
 ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-    if cost_matrix.is_empty() {
-        return (Vec::new(), Vec::new(), Vec::new());
-    }
-
-    let rows = cost_matrix.len();
-    let cols = cost_matrix[0].len();
-
-    let mut matches = Vec::new();
-    let mut unmatched_rows: HashSet<usize> = (0..rows).collect();
-    let mut unmatched_cols: HashSet<usize> = (0..cols).collect();
-
-    let mut costs: Vec<(f32, usize, usize)> = Vec::new();
-    for (r, row) in cost_matrix.iter().enumerate() {
-        for (c, &cost) in row.iter().enumerate() {
-            costs.push((cost, r, c));
-        }
-    }
-    costs.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-    for (cost, trk, det) in costs {
-        if cost > threshold {
-            break;
-        }
-        if unmatched_rows.contains(&trk) && unmatched_cols.contains(&det) {
-            matches.push((det, trk));
-            unmatched_rows.remove(&trk);
-            unmatched_cols.remove(&det);
-        }
-    }
-
-    (
-        matches,
-        unmatched_cols.into_iter().collect(),
-        unmatched_rows.into_iter().collect(),
-    )
+    let (matches, unmatched_rows, unmatched_cols) =
+        crate::utils::assignment::greedy_match(cost_matrix, threshold);
+    let matches = matches.into_iter().map(|(trk, det)| (det, trk)).collect();
+    (matches, unmatched_cols, unmatched_rows)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -2,7 +2,6 @@
 
 use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
-use std::collections::HashSet;
 
 /// Track state enumeration for SORT.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
@@ -261,48 +260,17 @@ impl Sort {
     }
 
     /// Greedy linear assignment.
+    ///
+    /// Rows are tracks and columns are detections; returns matches as
+    /// `(detection, track)` pairs alongside the unmatched detections and tracks.
     fn linear_assignment(
         &self,
         cost_matrix: &[Vec<f32>],
         thresh: f32,
     ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-        if cost_matrix.is_empty() {
-            return (Vec::new(), Vec::new(), Vec::new());
-        }
-
-        let rows = cost_matrix.len(); // tracks
-        let cols = cost_matrix[0].len(); // detections
-
-        let mut matches = Vec::new();
-        let mut unmatched_tracks: HashSet<usize> = (0..rows).collect();
-        let mut unmatched_dets: HashSet<usize> = (0..cols).collect();
-
-        // Collect all costs with indices
-        let mut costs: Vec<(f32, usize, usize)> = Vec::new();
-        for (r, row) in cost_matrix.iter().enumerate() {
-            for (c, &cost) in row.iter().enumerate() {
-                costs.push((cost, r, c));
-            }
-        }
-
-        // Sort by cost (ascending)
-        costs.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-        // Greedy matching
-        for (cost, trk_idx, det_idx) in costs {
-            if cost > thresh {
-                continue;
-            }
-            if unmatched_tracks.contains(&trk_idx) && unmatched_dets.contains(&det_idx) {
-                matches.push((det_idx, trk_idx)); // (detection, track) order
-                unmatched_tracks.remove(&trk_idx);
-                unmatched_dets.remove(&det_idx);
-            }
-        }
-
-        let unmatched_dets: Vec<usize> = unmatched_dets.into_iter().collect();
-        let unmatched_tracks: Vec<usize> = unmatched_tracks.into_iter().collect();
-
+        let (matches, unmatched_tracks, unmatched_dets) =
+            crate::utils::assignment::greedy_match(cost_matrix, thresh);
+        let matches = matches.into_iter().map(|(trk, det)| (det, trk)).collect();
         (matches, unmatched_dets, unmatched_tracks)
     }
 }

--- a/src/utils/assignment.rs
+++ b/src/utils/assignment.rs
@@ -1,0 +1,101 @@
+//! Greedy linear assignment shared by the trackers.
+//!
+//! All four trackers resolve a cost matrix into matches the same way: enumerate
+//! every (row, column) cost, sort ascending, and greedily accept a pair when both
+//! its row and column are still free and the cost does not exceed the threshold.
+
+use std::collections::HashSet;
+
+/// Greedily match rows to columns of a cost matrix.
+///
+/// `cost_matrix[r][c]` is the cost of pairing row `r` with column `c`. Pairs are
+/// accepted in ascending cost order while both endpoints are unmatched and the
+/// cost is `<= threshold`.
+///
+/// Returns `(matches, unmatched_rows, unmatched_cols)` where each match is a
+/// `(row, col)` pair. The unmatched vectors are unordered.
+pub fn greedy_match(
+    cost_matrix: &[Vec<f32>],
+    threshold: f32,
+) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
+    if cost_matrix.is_empty() {
+        return (Vec::new(), Vec::new(), Vec::new());
+    }
+
+    let rows = cost_matrix.len();
+    let cols = cost_matrix[0].len();
+
+    let mut matches = Vec::new();
+    let mut unmatched_rows: HashSet<usize> = (0..rows).collect();
+    let mut unmatched_cols: HashSet<usize> = (0..cols).collect();
+
+    let mut costs: Vec<(f32, usize, usize)> = Vec::with_capacity(rows * cols);
+    for (r, row) in cost_matrix.iter().enumerate() {
+        for (c, &cost) in row.iter().enumerate() {
+            costs.push((cost, r, c));
+        }
+    }
+    costs.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    for (cost, r, c) in costs {
+        if cost > threshold {
+            break;
+        }
+        if unmatched_rows.contains(&r) && unmatched_cols.contains(&c) {
+            matches.push((r, c));
+            unmatched_rows.remove(&r);
+            unmatched_cols.remove(&c);
+        }
+    }
+
+    (
+        matches,
+        unmatched_rows.into_iter().collect(),
+        unmatched_cols.into_iter().collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_matrix_matches_nothing() {
+        let (m, ur, uc) = greedy_match(&[], 0.5);
+        assert!(m.is_empty());
+        assert!(ur.is_empty());
+        assert!(uc.is_empty());
+    }
+
+    #[test]
+    fn picks_lowest_cost_pairs() {
+        // Row 0 prefers col 1 (0.1), row 1 prefers col 0 (0.2).
+        let cost = vec![vec![0.9, 0.1], vec![0.2, 0.8]];
+        let (mut m, ur, uc) = greedy_match(&cost, 0.5);
+        m.sort();
+        assert_eq!(m, vec![(0, 1), (1, 0)]);
+        assert!(ur.is_empty());
+        assert!(uc.is_empty());
+    }
+
+    #[test]
+    fn rejects_costs_above_threshold() {
+        let cost = vec![vec![0.9, 0.9], vec![0.9, 0.9]];
+        let (m, mut ur, mut uc) = greedy_match(&cost, 0.5);
+        ur.sort();
+        uc.sort();
+        assert!(m.is_empty());
+        assert_eq!(ur, vec![0, 1]);
+        assert_eq!(uc, vec![0, 1]);
+    }
+
+    #[test]
+    fn handles_more_rows_than_cols() {
+        let cost = vec![vec![0.1], vec![0.2], vec![0.3]];
+        let (m, mut ur, uc) = greedy_match(&cost, 1.0);
+        assert_eq!(m, vec![(0, 0)]);
+        ur.sort();
+        assert_eq!(ur, vec![1, 2]);
+        assert!(uc.is_empty());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,5 +2,6 @@
 //!
 //! This module provides common mathematical and geometric tools used by the trackers.
 
+pub mod assignment;
 pub mod geometry;
 pub mod kalman;


### PR DESCRIPTION
## Summary

The four trackers each reimplemented the same greedy cost-matrix matching: enumerate every cost, sort ascending, and accept a pair while both endpoints are free and the cost is within threshold. This extracts a single `greedy_match` into `utils::assignment` on the `(row, col)` convention, with its own unit tests.

- ByteTrack and DeepSORT use the same convention and call it directly.
- SORT and OC-SORT keep their `(detection, track)` output through a small adapter that flips the pairs, so no caller changes.

Note: the two convention families (`(detection, track)` for SORT/OC-SORT vs `(track, detection)` for ByteTrack/DeepSORT) are why a naive merge would have been wrong. The adapters preserve each tracker's exact contract.

No behavioral change. All tests pass (4 new unit tests added for the shared core); clippy clean on default and the `python` feature.

## Stack

Second of three. Targets `refactor/shared-bbox-conversions`. Merge that one first.