### PR TITLE
refactor: share DeepSORT tracker construction across Rust and Python

### DIFF
--- a/src/trackers/deepsort/mod.rs
+++ b/src/trackers/deepsort/mod.rs
@@ -19,6 +19,19 @@ use image::DynamicImage;
 use nn_matching::NearestNeighborDistanceMetric;
 use std::error::Error;
 
+/// Build the inner DeepSORT tracker shared by the Rust and Python constructors.
+fn build_tracker(
+    max_age: usize,
+    n_init: usize,
+    max_iou_distance: f32,
+    max_cosine_distance: f32,
+    nn_budget: usize,
+) -> DeepSortTracker {
+    let metric =
+        NearestNeighborDistanceMetric::new(Metric::Cosine, max_cosine_distance, Some(nn_budget));
+    DeepSortTracker::new(metric, max_age, n_init, max_iou_distance)
+}
+
 /// Deep SORT tracker implementation.
 ///
 /// Wraps the tracker logic and appearance feature extraction.
@@ -45,12 +58,13 @@ impl<E: AppearanceExtractor> DeepSort<E> {
         max_cosine_distance: f32,
         nn_budget: usize,
     ) -> Self {
-        let metric = NearestNeighborDistanceMetric::new(
-            Metric::Cosine,
+        let tracker = build_tracker(
+            max_age,
+            n_init,
+            max_iou_distance,
             max_cosine_distance,
-            Some(nn_budget),
+            nn_budget,
         );
-        let tracker = DeepSortTracker::new(metric, max_age, n_init, max_iou_distance);
 
         Self { extractor, tracker }
     }

--- a/src/trackers/deepsort/python.rs
+++ b/src/trackers/deepsort/python.rs
@@ -1,4 +1,3 @@
-use crate::trackers::deepsort::nn_matching::{Metric, NearestNeighborDistanceMetric};
 use crate::trackers::deepsort::tracker::DeepSortTracker;
 use crate::types::BoundingBox;
 use pyo3::prelude::*;
@@ -21,12 +20,13 @@ impl PyDeepSort {
         max_cosine_distance: f32,
         nn_budget: usize,
     ) -> Self {
-        let metric = NearestNeighborDistanceMetric::new(
-            Metric::Cosine,
+        let tracker = super::build_tracker(
+            max_age,
+            n_init,
+            max_iou_distance,
             max_cosine_distance,
-            Some(nn_budget),
+            nn_budget,
         );
-        let tracker = DeepSortTracker::new(metric, max_age, n_init, max_iou_distance);
         Self { tracker }
     }
 


### PR DESCRIPTION
## Summary

`DeepSort::new` and the PyO3 `PyDeepSort::new` both built the same cosine `NearestNeighborDistanceMetric` and `DeepSortTracker` by hand. This extracts a private `build_tracker` helper in the deepsort module and calls it from both constructors; the Python child module reaches it via `super`.

Also drops the now-unused `Metric` and `NearestNeighborDistanceMetric` imports from the Python bindings.

No behavioral change. All tests pass; clippy clean on default and the `python` feature.

## Stack

Top of three. Targets `refactor/shared-greedy-assignment`. Merge the two below it first.