### PR TITLE
docs: correct stale crate version and extractor example signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-trackforge = "0.1.9"
+trackforge = "0.2.0"
 ```
 
 To build the Python bindings from source (e.g. via `maturin develop`), enable the `python` feature:
 
 ```toml
 [dependencies]
-trackforge = { version = "0.1.9", features = ["python"] }
+trackforge = { version = "0.2.0", features = ["python"] }
 ```
 
 ## Quick Start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! impl AppearanceExtractor for MyExtractor {
 //!     fn extract(
-//!         &self,
+//!         &mut self,
 //!         image: &DynamicImage,
 //!         boxes: &[BoundingBox],
 //!     ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

Two documentation correctness fixes found during a repository audit.

- README install snippets referenced `trackforge = "0.1.9"`. The current published version is `0.2.0` (confirmed on crates.io), so the quick-start would pull an old release. Bumped both the plain and `python`-feature snippets.
- The `AppearanceExtractor` example in the crate-root docs (`src/lib.rs`) implemented `fn extract(&self, ...)`, but the trait method takes `&mut self`, so copying the example would not compile. Aligned the example with the trait.

Doc-only change: README markdown plus a `rust,ignore` doc comment. No compiled code is affected, so the build and test behavior is unchanged.