### PR TITLE
docs: add Conventional Commits and prek badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
     <a href="https://codecov.io/gh/onuralpszr/trackforge"><img src="https://img.shields.io/codecov/c/github/onuralpszr/trackforge?logo=codecov&logoColor=white&token=DHMFYRLJW1" alt="Coverage" /></a>
     <a href="https://deps.rs/repo/github/onuralpszr/trackforge"><img src="https://deps.rs/repo/github/onuralpszr/trackforge/status.svg" alt="dependency status" /></a>
     <a href="https://choosealicense.com/licenses/mit/"><img src="https://img.shields.io/crates/l/trackforge?logo=opensourceinitiative&logoColor=white" alt="License" /></a>
+    <a href="https://www.conventionalcommits.org/en/v1.0.0/"><img src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow?logo=conventionalcommits&logoColor=white" alt="Conventional Commits" /></a>
+    <a href="https://github.com/j178/prek"><img src="https://img.shields.io/badge/managed%20by-prek-FAB040?logo=precommit&logoColor=white" alt="prek" /></a>
 </p>
 
 ## Supported Trackers


### PR DESCRIPTION
## Summary

Two more badges for the README row.

- **Conventional Commits 1.0.0** badge linking to the spec at conventionalcommits.org, reflecting the commit style used in this repo.
- **prek** badge linking to [j178/prek](https://github.com/j178/prek), the Rust reimplementation of pre-commit that this repo already runs in CI (`autofix.yml`).

Both use logos to match the existing badges. Documentation only; no code or build impact.