### PR TITLE
refactor: share IoU cost-matrix construction in utils::geometry

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -572,4 +572,15 @@ mod tests {
             "re-activated track retains its original ID"
         );
     }
+
+    #[test]
+    fn test_iou_distance_empty_inputs() {
+        // update() guards empty pools before calling iou_distance, so exercise
+        // its own empty guard directly.
+        let tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        let (cost, rows, cols) = tracker.iou_distance(&[], &[]);
+        assert!(cost.is_empty());
+        assert!(rows.is_empty());
+        assert!(cols.is_empty());
+    }
 }

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -372,20 +372,11 @@ impl ByteTrack {
         let strack_boxes: Vec<[f32; 4]> = stracks.iter().map(|s| s.tlwh).collect();
         let det_boxes: Vec<[f32; 4]> = detections.iter().map(|s| s.tlwh).collect();
 
-        let mut cost_matrix = Vec::new();
         if strack_boxes.is_empty() || det_boxes.is_empty() {
-            return (cost_matrix, vec![], vec![]);
+            return (Vec::new(), vec![], vec![]);
         }
 
-        let ious = crate::utils::geometry::iou_batch(&strack_boxes, &det_boxes);
-
-        for iou_row in ious {
-            let mut row = Vec::new();
-            for iou in iou_row {
-                row.push(1.0 - iou);
-            }
-            cost_matrix.push(row);
-        }
+        let cost_matrix = crate::utils::geometry::iou_cost_matrix(&strack_boxes, &det_boxes);
 
         (
             cost_matrix,

--- a/src/trackers/deepsort/tracker.rs
+++ b/src/trackers/deepsort/tracker.rs
@@ -263,8 +263,6 @@ impl DeepSortTracker {
             );
         }
 
-        let mut cost_matrix = Vec::new();
-
         let track_boxes: Vec<[f32; 4]> = track_indices
             .iter()
             .map(|&i| self.tracks[i].to_tlwh())
@@ -277,12 +275,7 @@ impl DeepSortTracker {
             })
             .collect();
 
-        let ious = crate::utils::geometry::iou_batch(&track_boxes, &det_boxes);
-
-        for iou_row in ious {
-            let cost_row: Vec<f32> = iou_row.iter().map(|&iou| 1.0 - iou).collect();
-            cost_matrix.push(cost_row);
-        }
+        let cost_matrix = crate::utils::geometry::iou_cost_matrix(&track_boxes, &det_boxes);
 
         let (local_matches, local_unmatched_tracks, local_unmatched_dets) =
             min_cost_matching(&cost_matrix, self.max_iou_distance);

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -246,16 +246,8 @@ impl Sort {
         let track_boxes: Vec<[f32; 4]> = self.tracks.iter().map(|t| t.tlwh).collect();
         let det_boxes: Vec<[f32; 4]> = detections.iter().map(|d| d.tlwh).collect();
 
-        let ious = crate::utils::geometry::iou_batch(&track_boxes, &det_boxes);
+        let cost_matrix = crate::utils::geometry::iou_cost_matrix(&track_boxes, &det_boxes);
 
-        // Convert IoU to cost (1 - IoU)
-        let cost_matrix: Vec<Vec<f32>> = ious
-            .iter()
-            .map(|row| row.iter().map(|&iou| 1.0 - iou).collect())
-            .collect();
-
-        // Greedy matching (same as ByteTrack for now)
-        // TODO: Replace with proper Hungarian algorithm for optimal matching
         self.linear_assignment(&cost_matrix, 1.0 - self.iou_threshold)
     }
 

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -151,4 +151,30 @@ mod tests {
         assert_eq!(ious[1][1], 0.0);
         assert_eq!(ious[1][2], 0.0);
     }
+
+    #[test]
+    fn test_iou_cost_matrix() {
+        let tracks = vec![[0.0, 0.0, 10.0, 10.0], [100.0, 100.0, 10.0, 10.0]];
+        let dets = vec![[0.0, 0.0, 10.0, 10.0], [200.0, 200.0, 10.0, 10.0]];
+
+        let cost = iou_cost_matrix(&tracks, &dets);
+        assert_eq!(cost.len(), 2);
+        assert_eq!(cost[0].len(), 2);
+        // Perfect overlap -> cost 0; no overlap -> cost 1.
+        assert_eq!(cost[0][0], 0.0);
+        assert_eq!(cost[0][1], 1.0);
+        assert_eq!(cost[1][0], 1.0);
+        assert_eq!(cost[1][1], 1.0);
+    }
+
+    #[test]
+    fn test_iou_cost_matrix_empty() {
+        let tracks = vec![[0.0, 0.0, 10.0, 10.0]];
+        // No detections: one row per track, each empty.
+        let cost = iou_cost_matrix(&tracks, &[]);
+        assert_eq!(cost.len(), 1);
+        assert!(cost[0].is_empty());
+        // No tracks: empty matrix.
+        assert!(iou_cost_matrix(&[], &tracks).is_empty());
+    }
 }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -71,6 +71,18 @@ pub fn iou_batch(bboxes1: &[[f32; 4]], bboxes2: &[[f32; 4]]) -> Vec<Vec<f32>> {
     iou_matrix
 }
 
+/// Build an IoU association cost matrix between track boxes and detection boxes.
+///
+/// `result[i][j] = 1.0 - iou(tracks[i], dets[j])`, the cost used by the
+/// IoU-based trackers. The shape mirrors [`iou_batch`]: one row per track, one
+/// column per detection (so an empty `dets` yields one empty row per track).
+pub fn iou_cost_matrix(tracks: &[[f32; 4]], dets: &[[f32; 4]]) -> Vec<Vec<f32>> {
+    tracks
+        .iter()
+        .map(|t| dets.iter().map(|d| 1.0 - iou(t, d)).collect())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
SORT, ByteTrack and DeepSORT each built the same `1 - IoU` cost matrix from track and detection boxes by hand. This pulls that into `geometry::iou_cost_matrix` and uses it in all three, with a unit test for the helper. ByteTrack keeps its empty-input guard; OC-SORT is left alone because its second round still needs the raw IoU matrix for the `max_iou` check.