### PR TITLE
docs: add an mdbook guide alongside the mkdocs site

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,25 @@
+name: mdBook
+
+on:
+  push:
+    branches: [main, master]
+    paths: ["book/**", ".github/workflows/mdbook.yml"]
+  pull_request:
+    paths: ["book/**", ".github/workflows/mdbook.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install mdbook
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
+        with:
+          tool: mdbook
+      - name: Build
+        run: mdbook build book

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ docs/api/
 
 # cargo audit
 ~/.cargo/advisory-db
+
+# mdbook build output
+book/book/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,14 +54,14 @@ repos:
     hooks:
       - id: prettier
         types_or: [markdown, yaml, json]
-        exclude: ^(CHANGELOG\.md|target/|site/|docs/api/)
+        exclude: ^(CHANGELOG\.md|target/|site/|docs/api/|book/)
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
         args: [--fix]
-        exclude: ^(CHANGELOG\.md|target/|site/|docs/api/)
+        exclude: ^(CHANGELOG\.md|target/|site/|docs/api/|book/)
 
   # --- Python (pyo3 bindings / scripts) --------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,19 @@
+[book]
+title = "The Trackforge Book"
+description = "A guide to the Trackforge multi-object tracking library"
+authors = ["Onuralp Sezer"]
+language = "en"
+src = "src"
+
+[rust]
+edition = "2024"
+
+[output.html]
+git-repository-url = "https://github.com/onuralpszr/trackforge"
+edit-url-template = "https://github.com/onuralpszr/trackforge/edit/main/book/{path}"
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+
+[output.html.fold]
+enable = true
+level = 1

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+- [Getting Started](./getting-started.md)
+- [Trackers](./trackers/index.md)
+  - [SORT](./trackers/sort.md)
+  - [ByteTrack](./trackers/byte_track.md)
+  - [OC-SORT](./trackers/ocsort.md)
+  - [DeepSORT](./trackers/deepsort.md)
+- [Parameters](./parameters.md)
+- [Examples](./examples.md)

--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -3,13 +3,13 @@
 Runnable demos live under [`examples/`](https://github.com/onuralpszr/trackforge/tree/main/examples)
 in the repository, with a Python and a Rust entry per tracker.
 
-| Tracker   | Python                    | Rust                                  |
-| --------- | ------------------------- | ------------------------------------- |
-| ByteTrack | `byte_track_demo.py`      | `byte_track_demo.rs`                  |
-| DeepSORT  | `deepsort_demo.py`        | `deepsort_simple.rs`, `deepsort_ort.rs` |
-| OC-SORT   | `ocsort_demo.py`          | -                                     |
-| SORT      | `sort_yolo_demo.py`, `sort_rtdetr_demo.py` | -                    |
-| All four  | `tracker_comparison.py`   | -                                     |
+| Tracker   | Python                                     | Rust                                    |
+| --------- | ------------------------------------------ | --------------------------------------- |
+| ByteTrack | `byte_track_demo.py`                       | `byte_track_demo.rs`                    |
+| DeepSORT  | `deepsort_demo.py`                         | `deepsort_simple.rs`, `deepsort_ort.rs` |
+| OC-SORT   | `ocsort_demo.py`                           | -                                       |
+| SORT      | `sort_yolo_demo.py`, `sort_rtdetr_demo.py` | -                                       |
+| All four  | `tracker_comparison.py`                    | -                                       |
 
 ```bash
 # Python

--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -1,0 +1,26 @@
+# Examples
+
+Runnable demos live under [`examples/`](https://github.com/onuralpszr/trackforge/tree/main/examples)
+in the repository, with a Python and a Rust entry per tracker.
+
+| Tracker   | Python                    | Rust                                  |
+| --------- | ------------------------- | ------------------------------------- |
+| ByteTrack | `byte_track_demo.py`      | `byte_track_demo.rs`                  |
+| DeepSORT  | `deepsort_demo.py`        | `deepsort_simple.rs`, `deepsort_ort.rs` |
+| OC-SORT   | `ocsort_demo.py`          | -                                     |
+| SORT      | `sort_yolo_demo.py`, `sort_rtdetr_demo.py` | -                    |
+| All four  | `tracker_comparison.py`   | -                                     |
+
+```bash
+# Python
+python examples/python/byte_track_demo.py
+
+# Rust
+cargo run --example byte_track_demo
+cargo run --example deepsort_simple
+cargo run --example deepsort_ort --features advanced_examples
+```
+
+The Python demos use the usual detector stacks (`ultralytics`, `transformers` + `torch`,
+`torch` + `torchvision`); install what a given demo imports. The `deepsort_ort` Rust demo needs the
+`advanced_examples` feature (ONNX Runtime + OpenCV).

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,58 @@
+# Getting Started
+
+## Install
+
+### Rust
+
+```toml
+[dependencies]
+trackforge = "0.2"
+```
+
+### Python
+
+```bash
+pip install trackforge
+```
+
+## Your first tracker
+
+The detection format is the same everywhere: a list of `([x, y, w, h], score, class_id)` tuples,
+where `x, y` is the top-left corner in pixels.
+
+### Rust
+
+```rust
+use trackforge::trackers::byte_track::ByteTrack;
+
+let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+
+let detections = vec![
+    ([100.0, 100.0, 50.0, 100.0], 0.9, 0),
+    ([200.0, 200.0, 60.0, 120.0], 0.85, 0),
+];
+
+let tracks = tracker.update(detections);
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+### Python
+
+```python
+from trackforge import BYTETRACK
+
+tracker = BYTETRACK(track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6)
+
+detections = [
+    ([100.0, 100.0, 50.0, 100.0], 0.9, 0),
+    ([200.0, 200.0, 60.0, 120.0], 0.85, 0),
+]
+
+for track_id, tlwh, score, class_id in tracker.update(detections):
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
+Call `update` once per frame. Each tracker keeps its own state and returns the confirmed tracks
+for the current frame.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,24 @@
+# Introduction
+
+Trackforge is a unified, high-performance multi-object tracking library written in Rust and
+exposed to Python via PyO3. It implements four production-ready tracking algorithms on top of a
+shared Kalman filter, so you can swap trackers without changing your integration code.
+
+It is designed as the CPU "glue" between a GPU object detector and your application: you pass in
+detection boxes each frame and get back stable track identities.
+
+## Trackers at a glance
+
+| Tracker   | Appearance       | Matching             | Best for                                      |
+| --------- | ---------------- | -------------------- | --------------------------------------------- |
+| SORT      | None             | IoU                  | Simple scenes, maximum speed                  |
+| ByteTrack | None             | IoU (two-stage)      | Crowded scenes, low-confidence detections     |
+| OC-SORT   | None             | IoU + velocity (OCM) | Frequent brief occlusions, no Re-ID available |
+| DeepSORT  | Re-ID embeddings | Appearance + IoU     | Long occlusions, identity-sensitive use cases |
+
+Every tracker accepts the same detection tuple, `([x, y, w, h], score, class_id)`, and ships for
+both Python and Rust.
+
+This book is a narrative guide. For the full API surface, see the
+[Rust API on docs.rs](https://docs.rs/trackforge) and the
+[Python API reference](https://onuralpszr.github.io/trackforge/reference/python.html).

--- a/book/src/parameters.md
+++ b/book/src/parameters.md
@@ -1,0 +1,13 @@
+# Parameters
+
+The parameters are identical across Python and Rust. In Python they are keyword arguments to the
+tracker class; in Rust they are positional arguments to `Tracker::new(...)`. Each tracker's chapter
+documents its own parameters and tuning advice:
+
+- [SORT parameters](./trackers/sort.md#parameters)
+- [ByteTrack parameters](./trackers/byte_track.md#parameters)
+- [OC-SORT parameters](./trackers/ocsort.md#parameters)
+- [DeepSORT parameters](./trackers/deepsort.md#parameters)
+
+The same tables are also published on the
+[documentation site](https://onuralpszr.github.io/trackforge/parameters.html).

--- a/book/src/trackers/byte_track.md
+++ b/book/src/trackers/byte_track.md
@@ -1,0 +1,28 @@
+# ByteTrack
+
+**ByteTrack** ([arXiv 2110.06864](https://arxiv.org/abs/2110.06864)). A two-stage IoU tracker that
+associates _every_ detection, not just high-confidence ones, to recover objects that are briefly
+occluded or partially off-screen. A strong recall improvement over SORT at minimal extra cost.
+
+```rust
+use trackforge::trackers::byte_track::ByteTrack;
+
+let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+let tracks = tracker.update(vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)]);
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+## Parameters
+
+| Parameter      | Default | Description                                                         |
+| -------------- | ------- | ------------------------------------------------------------------- |
+| `track_thresh` | 0.5     | Confidence threshold separating high- and low-confidence detections |
+| `track_buffer` | 30      | Frames a lost track is buffered before deletion                     |
+| `match_thresh` | 0.8     | IoU threshold for stage-1 (high-confidence) matching                |
+| `det_thresh`   | 0.6     | Minimum confidence to initialise a new track                        |
+
+**Tuning:** lower `track_thresh` (~0.3) to feed more low-confidence detections into stage two; raise
+`track_buffer` (~60) when the detector drops frames; lower `match_thresh` (~0.7) for fast-moving
+objects where IoU falls off quickly.

--- a/book/src/trackers/deepsort.md
+++ b/book/src/trackers/deepsort.md
@@ -1,0 +1,60 @@
+# DeepSORT
+
+**DeepSORT** ([arXiv 1703.07402](https://arxiv.org/abs/1703.07402)). Extends SORT with a Re-ID
+appearance metric. Confirmed tracks are matched first by cosine distance on appearance embeddings
+(with Mahalanobis gating), then any remaining tracks fall back to IoU matching. Best for long-term
+identity maintenance.
+
+Unlike the other trackers, DeepSORT needs an appearance embedding per detection. In Rust you supply
+an `AppearanceExtractor`; in Python you pass embeddings directly.
+
+## Rust: implement an extractor
+
+```rust,ignore
+use trackforge::traits::AppearanceExtractor;
+use trackforge::types::BoundingBox;
+use image::DynamicImage;
+
+struct MyExtractor;
+
+impl AppearanceExtractor for MyExtractor {
+    fn extract(
+        &mut self,
+        image: &DynamicImage,
+        boxes: &[BoundingBox],
+    ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
+        // Crop each box, run your Re-ID model, return one embedding per box.
+        Ok(boxes.iter().map(|_| vec![0.0_f32; 128]).collect())
+    }
+}
+
+use trackforge::trackers::deepsort::DeepSort;
+let mut tracker = DeepSort::new(MyExtractor, 70, 3, 0.7, 0.2, 100);
+```
+
+## Python: bring your own embeddings
+
+```python
+from trackforge import DEEPSORT
+
+tracker = DEEPSORT(max_age=70, n_init=3, max_iou_distance=0.7, max_cosine_distance=0.2, nn_budget=100)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1] * 128]  # one vector per detection, from your Re-ID model
+
+for track_id, tlwh, score, class_id in tracker.update(detections, embeddings):
+    print(track_id, tlwh)
+```
+
+## Parameters
+
+| Parameter             | Default | Description                                        |
+| --------------------- | ------- | -------------------------------------------------- |
+| `max_age`             | 70      | Frames a track survives without a match            |
+| `n_init`              | 3       | Consecutive detections required to confirm a track |
+| `max_iou_distance`    | 0.7     | IoU distance threshold for the fallback IoU stage  |
+| `max_cosine_distance` | 0.2     | Cosine distance threshold for appearance matching  |
+| `nn_budget`           | 100     | Max appearance embeddings stored per track (FIFO)  |
+
+**Tuning:** lower `max_cosine_distance` (~0.15) for stricter Re-ID; raise `nn_budget` if appearance
+drifts over time; lower `n_init` to 1 when detections are reliable and you need tracks immediately.

--- a/book/src/trackers/index.md
+++ b/book/src/trackers/index.md
@@ -1,0 +1,16 @@
+# Trackers
+
+All four trackers share the same Kalman filter and the same detection input, and differ only in how
+they associate detections to existing tracks. Pick based on your scene and whether you have a Re-ID
+model.
+
+| Tracker                          | Appearance       | Matching             | When to use                                                 |
+| -------------------------------- | ---------------- | -------------------- | ----------------------------------------------------------- |
+| [SORT](./sort.md)                | None             | IoU                  | Simple scenes, highest speed, no occlusions                 |
+| [ByteTrack](./byte_track.md)     | None             | IoU (two-stage)      | Crowded scenes, low-confidence detections, short occlusions |
+| [OC-SORT](./ocsort.md)           | None             | IoU + velocity (OCM) | Frequent brief occlusions, no Re-ID available               |
+| [DeepSORT](./deepsort.md)        | Re-ID embeddings | Appearance + IoU     | Long occlusions, dense crowds, identity-sensitive cases     |
+
+The Kalman filter uses an 8-dimensional state `[x, y, a, h, vx, vy, va, vh]`, where `(x, y)` is the
+box centre, `a` is the aspect ratio, and `h` is the height. Detections in `[x, y, w, h]` (top-left)
+form are converted to and from this representation internally.

--- a/book/src/trackers/index.md
+++ b/book/src/trackers/index.md
@@ -4,12 +4,12 @@ All four trackers share the same Kalman filter and the same detection input, and
 they associate detections to existing tracks. Pick based on your scene and whether you have a Re-ID
 model.
 
-| Tracker                          | Appearance       | Matching             | When to use                                                 |
-| -------------------------------- | ---------------- | -------------------- | ----------------------------------------------------------- |
-| [SORT](./sort.md)                | None             | IoU                  | Simple scenes, highest speed, no occlusions                 |
-| [ByteTrack](./byte_track.md)     | None             | IoU (two-stage)      | Crowded scenes, low-confidence detections, short occlusions |
-| [OC-SORT](./ocsort.md)           | None             | IoU + velocity (OCM) | Frequent brief occlusions, no Re-ID available               |
-| [DeepSORT](./deepsort.md)        | Re-ID embeddings | Appearance + IoU     | Long occlusions, dense crowds, identity-sensitive cases     |
+| Tracker                      | Appearance       | Matching             | When to use                                                 |
+| ---------------------------- | ---------------- | -------------------- | ----------------------------------------------------------- |
+| [SORT](./sort.md)            | None             | IoU                  | Simple scenes, highest speed, no occlusions                 |
+| [ByteTrack](./byte_track.md) | None             | IoU (two-stage)      | Crowded scenes, low-confidence detections, short occlusions |
+| [OC-SORT](./ocsort.md)       | None             | IoU + velocity (OCM) | Frequent brief occlusions, no Re-ID available               |
+| [DeepSORT](./deepsort.md)    | Re-ID embeddings | Appearance + IoU     | Long occlusions, dense crowds, identity-sensitive cases     |
 
 The Kalman filter uses an 8-dimensional state `[x, y, a, h, vx, vy, va, vh]`, where `(x, y)` is the
 box centre, `a` is the aspect ratio, and `h` is the height. Detections in `[x, y, w, h]` (top-left)

--- a/book/src/trackers/ocsort.md
+++ b/book/src/trackers/ocsort.md
@@ -1,0 +1,37 @@
+# OC-SORT
+
+**Observation-Centric SORT** ([arXiv 2203.14360](https://arxiv.org/abs/2203.14360), CVPR 2023).
+Extends SORT with three observation-centric mechanisms that reduce drift during occlusions:
+
+- **OCV** computes velocity from consecutive detections rather than the Kalman state.
+- **OCM** adds a direction-consistency bonus before matching: a candidate whose direction from the
+  track's last observation aligns with the track's velocity gets a higher effective IoU.
+- **ORU** corrects the Kalman filter after re-association by replaying interpolated observations
+  between the last seen position and the current detection.
+
+No appearance features required, making it a strong upgrade over SORT when occlusions are common but
+Re-ID is unavailable.
+
+```rust
+use trackforge::trackers::ocsort::OcSort;
+
+let mut tracker = OcSort::new(30, 3, 0.3, 3, 0.2);
+let tracks = tracker.update(vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)]);
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+## Parameters
+
+| Parameter       | Default | Description                                                |
+| --------------- | ------- | ---------------------------------------------------------- |
+| `max_age`       | 30      | Frames to keep a lost track alive before deletion          |
+| `min_hits`      | 3       | Consecutive matched frames required to confirm a track     |
+| `iou_threshold` | 0.3     | Minimum IoU to associate a detection with a track          |
+| `delta_t`       | 3       | Observation window (frames) used to compute velocity (OCV) |
+| `inertia`       | 0.2     | Weight of the direction-consistency cost bonus (OCM)       |
+
+**Tuning:** raise `max_age` for long occlusions; raise `delta_t` for smoother velocity at the cost
+of responsiveness; raise `inertia` toward 1.0 for near-constant-velocity motion, lower it for
+erratic motion.

--- a/book/src/trackers/sort.md
+++ b/book/src/trackers/sort.md
@@ -1,0 +1,26 @@
+# SORT
+
+**Simple Online and Realtime Tracking** ([arXiv 1602.00763](https://arxiv.org/abs/1602.00763)).
+Pairs a Kalman filter with greedy IoU matching. Built for speed; best when objects rarely overlap.
+
+```rust
+use trackforge::trackers::sort::Sort;
+
+let mut tracker = Sort::new(1, 3, 0.3);
+let tracks = tracker.update(vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)]);
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+## Parameters
+
+| Parameter       | Default | Description                                            |
+| --------------- | ------- | ------------------------------------------------------ |
+| `max_age`       | 1       | Frames to keep a track alive without a detection match |
+| `min_hits`      | 3       | Consecutive matched frames before a track is confirmed |
+| `iou_threshold` | 0.3     | Minimum IoU to associate a detection with a track      |
+
+**Tuning:** raise `max_age` to bridge short occlusions (at the cost of more false tracks); lower
+`iou_threshold` for densely packed objects; raise `min_hits` to suppress false starts from a noisy
+detector.


### PR DESCRIPTION
Adds an mdbook guide under `book/` to sit next to the mkdocs site: an introduction, getting-started, a chapter for each tracker, parameters, and examples. There's a small CI job that runs `mdbook build` whenever `book/` changes so it can't rot, and the `book/book` output is gitignored. It builds but isn't deployed anywhere yet, so it won't touch the existing gh-pages site.