### PR TITLE
test: cover extractor error path and degenerate IoU

### DIFF
--- a/src/trackers/deepsort/mod.rs
+++ b/src/trackers/deepsort/mod.rs
@@ -165,4 +165,34 @@ mod tests {
         assert_eq!(tracks.len(), 1);
         assert!(tracks[0].is_confirmed());
     }
+
+    struct FailingExtractor;
+    impl AppearanceExtractor for FailingExtractor {
+        fn extract(
+            &mut self,
+            _image: &DynamicImage,
+            _bboxes: &[BoundingBox],
+        ) -> Result<Vec<Vec<f32>>, Box<dyn Error>> {
+            Err("extraction failed".into())
+        }
+    }
+
+    #[test]
+    fn test_deepsort_extractor_error_propagates() {
+        let mut tracker = DeepSort::new_default(FailingExtractor);
+        let image = DynamicImage::new_rgb8(100, 100);
+        let det = vec![(BoundingBox::new(10.0, 10.0, 20.0, 20.0), 0.9, 0)];
+        // Extraction fails, so update should surface the error.
+        assert!(tracker.update(&image, det).is_err());
+    }
+
+    #[test]
+    fn test_deepsort_empty_detections_skips_extraction() {
+        // No detections means the extractor is never called, so even a failing
+        // one is fine and update succeeds with no tracks.
+        let mut tracker = DeepSort::new_default(FailingExtractor);
+        let image = DynamicImage::new_rgb8(100, 100);
+        let tracks = tracker.update(&image, vec![]).unwrap();
+        assert!(tracks.is_empty());
+    }
 }

--- a/src/utils/geometry.rs
+++ b/src/utils/geometry.rs
@@ -105,6 +105,14 @@ mod tests {
     }
 
     #[test]
+    fn test_iou_degenerate_zero_area() {
+        // Two zero-area boxes give a zero union; the guard returns 0 instead of NaN.
+        let box1 = [0.0, 0.0, 0.0, 10.0]; // zero width
+        let box2 = [0.0, 0.0, 10.0, 0.0]; // zero height
+        assert_eq!(iou(&box1, &box2), 0.0);
+    }
+
+    #[test]
     fn test_iou_contained() {
         let box1 = [0.0, 0.0, 100.0, 100.0];
         let box2 = [25.0, 25.0, 50.0, 50.0];


### PR DESCRIPTION
Adds a few tests for branches that weren't exercised: `DeepSort::update` propagating an extractor error, the empty-detections path that skips extraction entirely, and the IoU zero-area guard that returns 0 instead of NaN.