### PR TITLE
docs: emit .html page urls so doc links resolve

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,11 @@ site_description: A unified, high-performance computer vision tracking library.
 repo_url: https://github.com/onuralpszr/trackforge
 repo_name: onuralpszr/trackforge
 
+# Emit page.html files instead of page/ directories so the .html links used
+# throughout the README and docs resolve (e.g. roadmap.html, parameters.html,
+# reference/python.html).
+use_directory_urls: false
+
 theme:
   name: material
   logo: logo.png


### PR DESCRIPTION
The docs site was using directory-style URLs (the mkdocs default) while the README and docs link to `.html` pages, so `roadmap.html`, `parameters.html`, and the pre-existing `reference/python.html` all 404'd. Setting `use_directory_urls: false` makes the pages emit as `.html` files so the links resolve.