### PR TITLE
docs: publish the mdbook under /book on the docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,17 @@ jobs:
       - name: Build Zensical site
         run: zensical build --clean
 
+      - name: Install mdbook
+        uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
+        with:
+          tool: mdbook
+
+      - name: Build the book under /book
+        run: |
+          mdbook build book
+          mkdir -p site/book
+          cp -r book/book/. site/book/
+
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The Python demos use the usual detector stacks: `ultralytics` (YOLO), `transform
 
 <a href="https://onuralpszr.github.io/trackforge/reference/python.html"><img src="https://img.shields.io/badge/Python%20API-docs-3776AB?logo=python&logoColor=white" alt="Python API" /></a>
 <a href="https://docs.rs/trackforge"><img src="https://img.shields.io/badge/Rust%20API-docs.rs-000000?logo=docsdotrs&logoColor=white" alt="Rust API" /></a>
+<a href="https://onuralpszr.github.io/trackforge/book/"><img src="https://img.shields.io/badge/Guide-mdBook-1F7087?logo=mdbook&logoColor=white" alt="Guide" /></a>
 
 ## Parameters
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -9,6 +9,7 @@ src = "src"
 edition = "2024"
 
 [output.html]
+site-url = "/trackforge/book/"
 git-repository-url = "https://github.com/onuralpszr/trackforge"
 edit-url-template = "https://github.com/onuralpszr/trackforge/edit/main/book/{path}"
 default-theme = "rust"


### PR DESCRIPTION
Builds the mdbook during the docs deploy and copies its output into site/book, so it's published to GitHub Pages at https://onuralpszr.github.io/trackforge/book/ alongside the zensical site. Sets the book's site-url to that path and adds a Guide badge to the README so people can find it.