### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-08
+
+### 🚜 Refactor
+
+- Centralize tlwh/xyah box conversions in `utils::geometry`
+- Share the greedy assignment core in `utils::assignment`
+- Share the IoU cost-matrix construction in `utils::geometry`
+- Share the DeepSORT tracker construction across Rust and Python
+- Use bool vectors instead of HashSet in `greedy_match`
+
+### 📚 Documentation
+
+- Overhaul the README and docs site (unified examples, badges, parameters and roadmap pages)
+- Add an mdBook guide, published at `/book` alongside the zensical site
+- Fix the docs site URLs so the `.html` links resolve
+- Document prek for the git hooks in CONTRIBUTING
+
+### 📦 Dependencies
+
+- Bump nalgebra from 0.34 to 0.35 (raises the MSRV to 1.89)
+
+### ⚙️ Miscellaneous
+
+- Parallelize the Rust CI into separate test, lint, and doc jobs
+- Add tests for the extractor error path, the empty IoU guards, and the degenerate IoU case
+
 ## [0.2.0] - 2026-05-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "trackforge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "image",
  "nalgebra 0.35.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trackforge"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "A unified, high-performance computer vision tracking library."
 rust-version = "1.89"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! [![MSRV](https://img.shields.io/crates/msrv/trackforge?logo=rust&logoColor=white)](https://crates.io/crates/trackforge)
 //! [![CI](https://img.shields.io/github/actions/workflow/status/onuralpszr/trackforge/CI.yml?branch=main&logo=githubactions&logoColor=white&label=CI)](https://github.com/onuralpszr/trackforge/actions/workflows/CI.yml)
 //! [![License: MIT](https://img.shields.io/crates/l/trackforge?logo=opensourceinitiative&logoColor=white)](https://opensource.org/licenses/MIT)
+//! [![Guide](https://img.shields.io/badge/Guide-mdBook-1F7087?logo=mdbook&logoColor=white)](https://onuralpszr.github.io/trackforge/book/)
 //!
 //! Trackforge is a unified, high-performance computer vision tracking library implemented in
 //! Rust and exposed as a Python package via PyO3.


### PR DESCRIPTION
Bump to 0.3.0 and record the changelog for this round. Also adds the mdBook Guide badge to the crate-level docs so it shows on docs.rs, matching the README.