### PR TITLE
chore: tag releases as v$version in commitizen config

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,7 +2,7 @@
 
 [tool.commitizen]
 name = "cz_customize"
-tag_format = "$version"
+tag_format = "v$version"
 version_type = "semver"
 version_provider = "cargo"
 update_changelog_on_bump = true


### PR DESCRIPTION
The release history uses v-prefixed tags (v0.2.0, v0.1.9) but .cz.toml had tag_format = "$version", so cz bump would produce unprefixed tags. Set it to v$version to match.