### PR TITLE
docs: bump install version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-trackforge = "0.2.0"
+trackforge = "0.3.0"
 ```
 
 To build the Python bindings from source (e.g. via `maturin develop`), enable the `python` feature:
 
 ```toml
 [dependencies]
-trackforge = { version = "0.2.0", features = ["python"] }
+trackforge = { version = "0.3.0", features = ["python"] }
 ```
 
 ## Quick Start

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-trackforge = "0.2"
+trackforge = "0.3"
 ```
 
 ### Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ pip install trackforge
 
 ```toml
 [dependencies]
-trackforge = "0.2"
+trackforge = "0.3"
 ```
 
 To enable the Python bindings feature when building from source:


### PR DESCRIPTION
The 0.3.0 release bumped Cargo.toml but the README, docs index, and book getting-started still showed 0.2. Update the install snippets to 0.3.