### PR TITLE
chore: add governance files and repo metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,27 @@
-# See <https://help.github.com/articles/about-codeowners/>
+# CODEOWNERS
+#
+# See https://help.github.com/articles/about-codeowners/ for details.
+# Uses the same pattern rules as .gitignore:
+# https://git-scm.com/docs/gitignore#_pattern_format
 
-# for more info about CODEOWNERS file
-
-# It uses the same pattern rule for gitignore file
-
-# <https://git-scm.com/docs/gitignore#_pattern_format>
-
-# Maintainers
-
+# Default owner for everything in the repo.
 * @onuralpszr
+
+# Rust core and trackers.
+/src/ @onuralpszr
+
+# Python bindings, stubs, and tests.
+/python/ @onuralpszr
+/tests/ @onuralpszr
+
+# Examples.
+/examples/ @onuralpszr
+
+# Documentation and guides.
+/docs/ @onuralpszr
+/book/ @onuralpszr
+
+# Build, CI, and repo metadata.
+/.github/ @onuralpszr
+/Cargo.toml @onuralpszr
+/pyproject.toml @onuralpszr

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [onuralpszr]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a problem with trackforge
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code sample (Rust or Python) that reproduces the problem.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: tracker
+    attributes:
+      label: Tracker
+      description: Which tracker is affected (SORT, ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT)?
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: trackforge version, language (Rust/Python) and version, and OS.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/onuralpszr/trackforge/discussions
+    about: Ask questions and discuss ideas with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea or improvement for trackforge
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem would this feature solve? What is the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you considered.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_tracker.yml
+++ b/.github/ISSUE_TEMPLATE/new_tracker.yml
@@ -1,0 +1,50 @@
+name: New tracker proposal
+description: Propose adding a new tracking algorithm to trackforge
+labels: ["new-tracker"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please read docs/adding-a-tracker.md before proposing a new tracker.
+  - type: input
+    id: name
+    attributes:
+      label: Tracker name
+      description: The name of the algorithm (for example Deep OC-SORT).
+    validations:
+      required: true
+  - type: input
+    id: paper
+    attributes:
+      label: Paper
+      description: arXiv id or link to the paper.
+    validations:
+      required: true
+  - type: input
+    id: reference
+    attributes:
+      label: Reference implementation
+      description: Link to the original or a well-known reference implementation.
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: Algorithm summary
+      description: How does it associate detections with tracks? What does it build on (motion, appearance, two-stage matching)?
+    validations:
+      required: true
+  - type: textarea
+    id: builds_on
+    attributes:
+      label: Reuse
+      description: Which existing trackforge building blocks can it reuse (utils::kalman, utils::geometry, utils::assignment, trackers::common, deepsort::nn_matching)?
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: I am willing to help implement this tracker.
+        - label: This tracker appears on the roadmap (docs/roadmap.md).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!--
+Read docs/COMMIT_GUIDELINES.md before opening this PR.
+Write the description in plain prose. Do not add section headers like "## Summary",
+robotic filler, AI-attribution lines, em dashes, or co-author trailers.
+-->
+
+What does this PR change and why?
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] New tracker
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other
+
+## Checklist
+
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test` and `cargo test --features python` pass
+- [ ] Docs and examples updated if behavior or the public API changed
+- [ ] Commits are signed off (`git commit -s`) and follow the commit guidelines
+- [ ] I disclosed any use of AI tools (see CONTRIBUTING.md)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "trackforge"
+abstract: >-
+  A unified, high-performance computer vision multi-object tracking library
+  implemented in Rust with Python bindings. Provides real-time tracking
+  algorithms (SORT, ByteTrack, OC-SORT, DeepSORT) optimized for speed.
+type: software
+authors:
+  - family-names: "Sezer"
+    given-names: "Onuralp"
+    email: "thunderbirdtr@gmail.com"
+license: MIT
+repository-code: "https://github.com/onuralpszr/trackforge"
+url: "https://github.com/onuralpszr/trackforge"
+keywords:
+  - multi-object-tracking
+  - computer-vision
+  - rust
+  - python
+  - sort
+  - bytetrack
+  - oc-sort
+  - deepsort

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community
+include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and
+  learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response to
+any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
+the community leaders responsible for enforcement at thunderbirdtr@gmail.com. All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter
+of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     <a href="https://choosealicense.com/licenses/mit/"><img src="https://img.shields.io/crates/l/trackforge?logo=opensourceinitiative&logoColor=white" alt="License" /></a>
     <a href="https://www.conventionalcommits.org/en/v1.0.0/"><img src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow?logo=conventionalcommits&logoColor=white" alt="Conventional Commits" /></a>
     <a href="https://github.com/j178/prek"><img src="https://img.shields.io/badge/managed%20by-prek-FAB040?logo=precommit&logoColor=white" alt="prek" /></a>
+    <a href="https://github.com/onuralpszr/trackforge/blob/main/CITATION.cff"><img src="https://img.shields.io/badge/Cite%20this-repository-blue?logo=googlescholar&logoColor=white" alt="Cite this repository" /></a>
 </p>
 
 ## Supported Trackers
@@ -305,6 +306,58 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 ## Roadmap
 
 Planned trackers and milestones live on the [Roadmap page](https://onuralpszr.github.io/trackforge/roadmap.html).
+
+## Citation
+
+If you use trackforge in your research or project, please cite it. GitHub's "Cite this
+repository" button reads the [`CITATION.cff`](CITATION.cff) metadata, or use:
+
+```bibtex
+@software{trackforge,
+  author  = {Sezer, Onuralp},
+  title   = {trackforge: A unified, high-performance multi-object tracking library},
+  url     = {https://github.com/onuralpszr/trackforge},
+  license = {MIT}
+}
+```
+
+trackforge provides clean-room implementations of published tracking algorithms. Please
+also cite the paper for the tracker you use:
+
+<details>
+<summary>Per-tracker citations</summary>
+
+```bibtex
+@inproceedings{bewley2016sort,
+  title={Simple Online and Realtime Tracking},
+  author={Bewley, Alex and Ge, Zongyuan and Ott, Lionel and Ramos, Fabio and Upcroft, Ben},
+  booktitle={IEEE International Conference on Image Processing (ICIP)},
+  year={2016}
+}
+
+@inproceedings{wojke2017deepsort,
+  title={Simple Online and Realtime Tracking with a Deep Association Metric},
+  author={Wojke, Nicolai and Bewley, Alex and Paulus, Dietrich},
+  booktitle={IEEE International Conference on Image Processing (ICIP)},
+  year={2017}
+}
+
+@inproceedings{zhang2022bytetrack,
+  title={ByteTrack: Multi-Object Tracking by Associating Every Detection Box},
+  author={Zhang, Yifu and Sun, Peize and Jiang, Yi and Yu, Dongdong and Weng, Fucheng and Yuan, Zehuan and Luo, Ping and Liu, Wenyu and Wang, Xinggang},
+  booktitle={Proceedings of the European Conference on Computer Vision (ECCV)},
+  year={2022}
+}
+
+@inproceedings{cao2023ocsort,
+  title={Observation-Centric SORT: Rethinking SORT for Robust Multi-Object Tracking},
+  author={Cao, Jinkun and Pang, Jiangmiao and Weng, Xinshuo and Khirodkar, Rawal and Kitani, Kris},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  year={2023}
+}
+```
+
+</details>
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security policy
+
+## Supported versions
+
+trackforge is under active development. Security fixes are applied to the latest
+released version on crates.io and PyPI. Please upgrade to the latest version before
+reporting an issue.
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab.
+2. Choose **Report a vulnerability**.
+
+If you cannot use that channel, email the maintainer at thunderbirdtr@gmail.com with the
+details. Include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- Affected version(s) and platform.
+
+You can expect an initial response within a few business days. We will work with you to
+understand and resolve the issue and will credit you in the release notes unless you
+prefer to remain anonymous.
+
+## Scope
+
+This project is a library that processes detection inputs. Reports about memory safety,
+denial of service from malformed inputs, or unsafe handling of dependencies are in scope.


### PR DESCRIPTION
Removes the empty bytetrack leftover directory and adds a code of conduct, security policy, citation metadata, issue templates, a PR template, funding config, and a commit guidelines doc. Adds a citation section and badge to the README.