### PR TITLE
refactor(trackers): share IoU association helper

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -238,18 +238,11 @@ impl ByteTrack {
         strack_pool.extend_from_slice(&tracked_stracks);
         strack_pool.extend_from_slice(&self.lost_stracks);
 
-        // First matching
+        // First matching: high-confidence detections against tracked + lost tracks.
+        let pool_boxes: Vec<[f32; 4]> = strack_pool.iter().map(|s| s.tlwh).collect();
+        let high_boxes: Vec<[f32; 4]> = detections_high.iter().map(|s| s.tlwh).collect();
         let (matches, u_track, u_detection) =
-            if strack_pool.is_empty() || detections_high.is_empty() {
-                (
-                    Vec::new(),
-                    (0..strack_pool.len()).collect(),
-                    (0..detections_high.len()).collect(),
-                )
-            } else {
-                let (dists, _, _) = self.iou_distance(&strack_pool, &detections_high);
-                self.linear_assignment(&dists, self.match_thresh) // Use struct match_thresh (0.8)
-            };
+            crate::utils::assignment::iou_match(&pool_boxes, &high_boxes, self.match_thresh);
 
         for (itrack, idet) in matches {
             let track = &mut strack_pool[itrack];
@@ -282,17 +275,11 @@ impl ByteTrack {
             }
         }
 
+        // Second matching: low-confidence detections against still-tracked leftovers.
+        let r_tracked_boxes: Vec<[f32; 4]> = r_tracked_stracks.iter().map(|s| s.tlwh).collect();
+        let low_boxes: Vec<[f32; 4]> = detections_low.iter().map(|s| s.tlwh).collect();
         let (matches, u_track_second, _) =
-            if r_tracked_stracks.is_empty() || detections_low.is_empty() {
-                (
-                    Vec::new(),
-                    (0..r_tracked_stracks.len()).collect(),
-                    (0..detections_low.len()).collect(),
-                )
-            } else {
-                let (dists, _, _) = self.iou_distance(&r_tracked_stracks, &detections_low);
-                self.linear_assignment(&dists, 0.5) // 0.5 low thresh
-            };
+            crate::utils::assignment::iou_match(&r_tracked_boxes, &low_boxes, 0.5);
 
         for (itrack, idet) in matches {
             let track = &mut r_tracked_stracks[itrack];
@@ -362,39 +349,6 @@ impl ByteTrack {
 
         // Return *tracked* stracks
         output_stracks
-    }
-
-    fn iou_distance(
-        &self,
-        stracks: &[STrack],
-        detections: &[STrack],
-    ) -> (Vec<Vec<f32>>, Vec<usize>, Vec<usize>) {
-        let strack_boxes: Vec<[f32; 4]> = stracks.iter().map(|s| s.tlwh).collect();
-        let det_boxes: Vec<[f32; 4]> = detections.iter().map(|s| s.tlwh).collect();
-
-        if strack_boxes.is_empty() || det_boxes.is_empty() {
-            return (Vec::new(), vec![], vec![]);
-        }
-
-        let cost_matrix = crate::utils::geometry::iou_cost_matrix(&strack_boxes, &det_boxes);
-
-        (
-            cost_matrix,
-            (0..strack_boxes.len()).collect(),
-            (0..det_boxes.len()).collect(),
-        )
-    }
-
-    /// Greedy linear assignment.
-    ///
-    /// Rows are tracks and columns are detections; returns matches as
-    /// `(track, detection)` pairs alongside the unmatched tracks and detections.
-    fn linear_assignment(
-        &self,
-        cost_matrix: &[Vec<f32>],
-        thresh: f32,
-    ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-        crate::utils::assignment::greedy_match(cost_matrix, thresh)
     }
 }
 
@@ -571,16 +525,5 @@ mod tests {
             out3[0].track_id, id,
             "re-activated track retains its original ID"
         );
-    }
-
-    #[test]
-    fn test_iou_distance_empty_inputs() {
-        // update() guards empty pools before calling iou_distance, so exercise
-        // its own empty guard directly.
-        let tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
-        let (cost, rows, cols) = tracker.iou_distance(&[], &[]);
-        assert!(cost.is_empty());
-        assert!(rows.is_empty());
-        assert!(cols.is_empty());
     }
 }

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -233,35 +233,15 @@ impl Sort {
     }
 
     /// Associate detections to existing tracks using IoU.
+    ///
+    /// Returns matches as `(detection, track)` pairs alongside the unmatched
+    /// detections and tracks.
     fn associate(&self, detections: &[Detection]) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-        if self.tracks.is_empty() {
-            return (Vec::new(), (0..detections.len()).collect(), Vec::new());
-        }
-
-        if detections.is_empty() {
-            return (Vec::new(), Vec::new(), (0..self.tracks.len()).collect());
-        }
-
-        // Compute IoU cost matrix
         let track_boxes: Vec<[f32; 4]> = self.tracks.iter().map(|t| t.tlwh).collect();
         let det_boxes: Vec<[f32; 4]> = detections.iter().map(|d| d.tlwh).collect();
 
-        let cost_matrix = crate::utils::geometry::iou_cost_matrix(&track_boxes, &det_boxes);
-
-        self.linear_assignment(&cost_matrix, 1.0 - self.iou_threshold)
-    }
-
-    /// Greedy linear assignment.
-    ///
-    /// Rows are tracks and columns are detections; returns matches as
-    /// `(detection, track)` pairs alongside the unmatched detections and tracks.
-    fn linear_assignment(
-        &self,
-        cost_matrix: &[Vec<f32>],
-        thresh: f32,
-    ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
         let (matches, unmatched_tracks, unmatched_dets) =
-            crate::utils::assignment::greedy_match(cost_matrix, thresh);
+            crate::utils::assignment::iou_match(&track_boxes, &det_boxes, 1.0 - self.iou_threshold);
         let matches = matches.into_iter().map(|(trk, det)| (det, trk)).collect();
         (matches, unmatched_dets, unmatched_tracks)
     }

--- a/src/utils/assignment.rs
+++ b/src/utils/assignment.rs
@@ -4,6 +4,8 @@
 //! every (row, column) cost, sort ascending, and greedily accept a pair when both
 //! its row and column are still free and the cost does not exceed the threshold.
 
+use crate::utils::geometry::iou_cost_matrix;
+
 /// Greedily match rows to columns of a cost matrix.
 ///
 /// `cost_matrix[r][c]` is the cost of pairing row `r` with column `c`. Pairs are
@@ -54,6 +56,32 @@ pub fn greedy_match(
     (matches, unmatched_rows, unmatched_cols)
 }
 
+/// Greedily associate track boxes to detection boxes by IoU.
+///
+/// Builds the `1 - IoU` cost matrix between `track_boxes` and `det_boxes` and runs
+/// [`greedy_match`] on it. `cost_threshold` is the maximum acceptable `1 - IoU` cost,
+/// so a pair is matched only when `IoU >= 1 - cost_threshold`.
+///
+/// Returns `(matches, unmatched_tracks, unmatched_dets)` where each match is a
+/// `(track, detection)` pair. When either side is empty no match is possible and the
+/// full index range of the non-empty side is returned as unmatched.
+pub fn iou_match(
+    track_boxes: &[[f32; 4]],
+    det_boxes: &[[f32; 4]],
+    cost_threshold: f32,
+) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
+    if track_boxes.is_empty() || det_boxes.is_empty() {
+        return (
+            Vec::new(),
+            (0..track_boxes.len()).collect(),
+            (0..det_boxes.len()).collect(),
+        );
+    }
+
+    let cost_matrix = iou_cost_matrix(track_boxes, det_boxes);
+    greedy_match(&cost_matrix, cost_threshold)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,5 +124,42 @@ mod tests {
         ur.sort();
         assert_eq!(ur, vec![1, 2]);
         assert!(uc.is_empty());
+    }
+
+    #[test]
+    fn iou_match_pairs_overlapping_boxes() {
+        let tracks = vec![[0.0, 0.0, 10.0, 10.0], [100.0, 100.0, 10.0, 10.0]];
+        let dets = vec![[100.0, 100.0, 10.0, 10.0], [0.0, 0.0, 10.0, 10.0]];
+        let (mut m, ut, ud) = iou_match(&tracks, &dets, 1.0 - 0.3);
+        m.sort();
+        // track 0 overlaps det 1, track 1 overlaps det 0.
+        assert_eq!(m, vec![(0, 1), (1, 0)]);
+        assert!(ut.is_empty());
+        assert!(ud.is_empty());
+    }
+
+    #[test]
+    fn iou_match_leaves_non_overlapping_unmatched() {
+        let tracks = vec![[0.0, 0.0, 10.0, 10.0]];
+        let dets = vec![[500.0, 500.0, 10.0, 10.0]];
+        let (m, ut, ud) = iou_match(&tracks, &dets, 1.0 - 0.3);
+        assert!(m.is_empty());
+        assert_eq!(ut, vec![0]);
+        assert_eq!(ud, vec![0]);
+    }
+
+    #[test]
+    fn iou_match_handles_empty_sides() {
+        let tracks = vec![[0.0, 0.0, 10.0, 10.0]];
+        // No detections: the single track is unmatched.
+        let (m, ut, ud) = iou_match(&tracks, &[], 0.7);
+        assert!(m.is_empty());
+        assert_eq!(ut, vec![0]);
+        assert!(ud.is_empty());
+        // No tracks: the single detection is unmatched.
+        let (m, ut, ud) = iou_match(&[], &tracks, 0.7);
+        assert!(m.is_empty());
+        assert!(ut.is_empty());
+        assert_eq!(ud, vec![0]);
     }
 }


### PR DESCRIPTION
Adds utils::assignment::iou_match, which builds the 1 - IoU cost matrix and runs the greedy match in one place and returns all-unmatched when either side is empty. SORT and ByteTrack now call it instead of carrying their own empty guards, iou_distance, and linear_assignment wrappers.