### PR TITLE
refactor(trackers): add shared common module and migrate SORT

### DIFF
--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -1,0 +1,59 @@
+//! Building blocks shared across the trackers.
+//!
+//! [`TrackState`] is the common confirm/delete lifecycle used by the IoU and
+//! appearance trackers, and [`KalmanTrack`] wraps the per-track Kalman state with
+//! the predict/update mechanics they all repeat.
+
+use crate::utils::geometry::xyah_to_tlwh;
+use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
+
+/// Lifecycle state of a track.
+///
+/// A track starts [`Tentative`](TrackState::Tentative), becomes
+/// [`Confirmed`](TrackState::Confirmed) once it has accumulated enough matches, and
+/// is [`Deleted`](TrackState::Deleted) when it ages out or fails confirmation.
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum TrackState {
+    /// Newly created; not yet confirmed by enough matches.
+    Tentative,
+    /// Confirmed active track returned to callers.
+    Confirmed,
+    /// Marked for removal.
+    Deleted,
+}
+
+/// Per-track Kalman state plus the predict/update steps every tracker repeats.
+///
+/// Holds the 8-dimensional mean and covariance and applies the shared
+/// [`KalmanFilter`]. The owning track keeps its own box, score, and lifecycle
+/// fields and delegates the filtering to this type.
+#[derive(Debug, Clone)]
+pub struct KalmanTrack {
+    /// Kalman filter state mean (`[x, y, a, h, vx, vy, va, vh]`).
+    pub mean: StateVector,
+    /// Kalman filter state covariance.
+    pub covariance: CovarianceMatrix,
+}
+
+impl KalmanTrack {
+    /// Initialise the filter from a first measurement in XYAH form.
+    pub fn initiate(measurement: &MeasurementVector, kf: &KalmanFilter) -> Self {
+        let (mean, covariance) = kf.initiate(measurement);
+        Self { mean, covariance }
+    }
+
+    /// Run one Kalman prediction step and return the refreshed TLWH box.
+    pub fn predict(&mut self, kf: &KalmanFilter) -> [f32; 4] {
+        let (mean, covariance) = kf.predict(&self.mean, &self.covariance);
+        self.mean = mean;
+        self.covariance = covariance;
+        xyah_to_tlwh(&self.mean)
+    }
+
+    /// Correct the state with a matched measurement in XYAH form.
+    pub fn update(&mut self, measurement: &MeasurementVector, kf: &KalmanFilter) {
+        let (mean, covariance) = kf.update(&self.mean, &self.covariance, measurement);
+        self.mean = mean;
+        self.covariance = covariance;
+    }
+}

--- a/src/trackers/mod.rs
+++ b/src/trackers/mod.rs
@@ -3,6 +3,7 @@
 //! This module contains the core tracking logic for algorithms like ByteTrack, SORT, DeepSORT, and OC-SORT.
 
 pub mod byte_track;
+pub mod common;
 pub mod deepsort;
 pub mod ocsort;
 pub mod sort;

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -6,7 +6,7 @@ use crate::utils::kalman::KalmanFilter;
 
 /// Track state enumeration for SORT.
 ///
-/// Alias of the shared [`TrackState`](crate::trackers::common::TrackState).
+/// Alias of the shared [`TrackState`].
 pub type SortTrackState = TrackState;
 
 /// A single track in SORT.

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -1,18 +1,13 @@
 #![doc = include_str!("README.md")]
 
-use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
-use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
+use crate::trackers::common::{KalmanTrack, TrackState};
+use crate::utils::geometry::tlwh_to_xyah;
+use crate::utils::kalman::KalmanFilter;
 
 /// Track state enumeration for SORT.
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub enum SortTrackState {
-    /// Track is tentative (not yet confirmed).
-    Tentative,
-    /// Track is confirmed and active.
-    Confirmed,
-    /// Track is deleted.
-    Deleted,
-}
+///
+/// Alias of the shared [`TrackState`](crate::trackers::common::TrackState).
+pub type SortTrackState = TrackState;
 
 /// A single track in SORT.
 #[derive(Debug, Clone)]
@@ -35,8 +30,7 @@ pub struct SortTrack {
     pub age: usize,
 
     // Kalman Filter state
-    mean: StateVector,
-    covariance: CovarianceMatrix,
+    kalman: KalmanTrack,
 }
 
 impl SortTrack {
@@ -49,7 +43,7 @@ impl SortTrack {
         track_id: u64,
     ) -> Self {
         let measurement = tlwh_to_xyah(&tlwh);
-        let (mean, covariance) = kf.initiate(&measurement);
+        let kalman = KalmanTrack::initiate(&measurement, kf);
 
         Self {
             tlwh,
@@ -60,29 +54,21 @@ impl SortTrack {
             hits: 1,
             time_since_update: 0,
             age: 1,
-            mean,
-            covariance,
+            kalman,
         }
     }
 
     /// Predict the next state using Kalman filter.
     pub fn predict(&mut self, kf: &KalmanFilter) {
-        let (mean, covariance) = kf.predict(&self.mean, &self.covariance);
-        self.mean = mean;
-        self.covariance = covariance;
+        self.tlwh = self.kalman.predict(kf);
         self.age += 1;
         self.time_since_update += 1;
-
-        // Update tlwh from predicted state
-        self.tlwh = xyah_to_tlwh(&self.mean);
     }
 
     /// Update the track with a matched detection.
     fn update(&mut self, detection: &Detection, kf: &KalmanFilter) {
         let measurement = tlwh_to_xyah(&detection.tlwh);
-        let (mean, covariance) = kf.update(&self.mean, &self.covariance, &measurement);
-        self.mean = mean;
-        self.covariance = covariance;
+        self.kalman.update(&measurement, kf);
 
         self.tlwh = detection.tlwh;
         self.score = detection.score;


### PR DESCRIPTION
Adds trackers::common with a shared TrackState enum and a KalmanTrack helper that holds a track's mean and covariance and the predict/update steps. SORT moves onto them: SortTrackState becomes an alias of the shared TrackState, and SortTrack delegates its Kalman state to KalmanTrack instead of holding the fields directly.