### PR TITLE
refactor(trackers): add unified Tracker trait

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -499,6 +499,14 @@ mod tests {
     }
 
     #[test]
+    fn test_bytetrack_tracker_trait() {
+        use crate::traits::Tracker;
+        let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        let tracks = Tracker::update(&mut tracker, vec![([10.0, 10.0, 50.0, 100.0], 0.9, 0)]);
+        assert_eq!(tracks.len(), 1);
+    }
+
+    #[test]
     fn test_bytetrack_id_sequential() {
         let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
 

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -352,6 +352,14 @@ impl ByteTrack {
     }
 }
 
+impl crate::traits::Tracker for ByteTrack {
+    type Track = STrack;
+
+    fn update(&mut self, detections: Vec<crate::traits::Detection>) -> Vec<STrack> {
+        self.update(detections)
+    }
+}
+
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -630,6 +630,14 @@ mod tests {
     }
 
     #[test]
+    fn test_ocsort_tracker_trait() {
+        use crate::traits::Tracker;
+        let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
+        let tracks = Tracker::update(&mut tracker, vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
+        assert_eq!(tracks.len(), 1);
+    }
+
+    #[test]
     fn test_ocsort_two_objects_separate_ids() {
         let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
 

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -491,6 +491,14 @@ impl Default for OcSort {
     }
 }
 
+impl crate::traits::Tracker for OcSort {
+    type Track = OcSortTrack;
+
+    fn update(&mut self, detections: Vec<crate::traits::Detection>) -> Vec<OcSortTrack> {
+        self.update(detections)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Greedy matching
 // ---------------------------------------------------------------------------

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -239,6 +239,14 @@ impl Default for Sort {
     }
 }
 
+impl crate::traits::Tracker for Sort {
+    type Track = SortTrack;
+
+    fn update(&mut self, detections: Vec<crate::traits::Detection>) -> Vec<SortTrack> {
+        self.update(detections)
+    }
+}
+
 // Python bindings
 #[cfg(feature = "python")]
 use pyo3::prelude::*;

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -415,6 +415,14 @@ mod tests {
     }
 
     #[test]
+    fn test_sort_tracker_trait() {
+        use crate::traits::Tracker;
+        let mut tracker = Sort::new(1, 1, 0.3);
+        let tracks = Tracker::update(&mut tracker, vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)]);
+        assert_eq!(tracks.len(), 1);
+    }
+
+    #[test]
     fn test_sort_id_sequential() {
         let mut tracker = Sort::new(1, 1, 0.3);
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,6 +2,39 @@ use crate::types::BoundingBox;
 use image::DynamicImage;
 use std::error::Error;
 
+/// A detection passed to a tracker: `(tlwh, score, class_id)`.
+///
+/// The box is in TLWH (top-left x, top-left y, width, height) format.
+pub type Detection = ([f32; 4], f32, i64);
+
+/// Common interface for the detection-only trackers.
+///
+/// SORT, ByteTrack, and OC-SORT all consume a frame's detections and return the
+/// active tracks, so generic code can drive any of them through this trait.
+/// DeepSORT needs the source frame to extract appearance features and therefore
+/// keeps its own `update(&image, detections)` method instead of this trait.
+///
+/// ```
+/// use trackforge::traits::{Detection, Tracker};
+/// use trackforge::trackers::sort::Sort;
+///
+/// fn run_one<T: Tracker>(tracker: &mut T, dets: Vec<Detection>) -> Vec<T::Track> {
+///     tracker.update(dets)
+/// }
+///
+/// let mut tracker = Sort::new(1, 1, 0.3);
+/// let tracks = run_one(&mut tracker, vec![([0.0, 0.0, 10.0, 10.0], 0.9, 0)]);
+/// assert_eq!(tracks.len(), 1);
+/// ```
+pub trait Tracker {
+    /// The track type this tracker yields.
+    type Track;
+
+    /// Update the tracker with the current frame's detections and return the
+    /// active tracks for this frame.
+    fn update(&mut self, detections: Vec<Detection>) -> Vec<Self::Track>;
+}
+
 /// Trait for extracting appearance features (embeddings) from images.
 ///
 /// This allows decoupling the tracker logic (DeepSORT) from the model execution


### PR DESCRIPTION
Adds a Tracker trait in traits.rs with a Detection alias and an associated Track type, implemented by SORT, ByteTrack, and OC-SORT so generic code can drive any of them through update(). DeepSORT keeps its image-plus-detections update and does not implement the trait. Each trait impl delegates to the existing inherent update method.