### PR TITLE
feat(deep_ocsort): add Deep OC-SORT tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,19 @@
 
 ## Supported Trackers
 
-| Tracker                                       | Type                           | Appearance (Re-ID) |
-| --------------------------------------------- | ------------------------------ | ------------------ |
-| [ByteTrack](https://arxiv.org/abs/2110.06864) | IoU + confidence association   | No                 |
-| [DeepSORT](https://arxiv.org/abs/1703.07402)  | IoU + cosine distance          | Yes (pluggable)    |
-| [OC-SORT](https://arxiv.org/abs/2203.14360)   | IoU + velocity direction (OCM) | No                 |
-| [SORT](https://arxiv.org/abs/1602.00763)      | IoU + Kalman filter            | No                 |
+| Tracker                                          | Type                              | Appearance (Re-ID) |
+| ------------------------------------------------ | --------------------------------- | ------------------ |
+| [ByteTrack](https://arxiv.org/abs/2110.06864)    | IoU + confidence association      | No                 |
+| [DeepSORT](https://arxiv.org/abs/1703.07402)     | IoU + cosine distance             | Yes (pluggable)    |
+| [OC-SORT](https://arxiv.org/abs/2203.14360)      | IoU + velocity direction (OCM)    | No                 |
+| [Deep OC-SORT](https://arxiv.org/abs/2302.11813) | IoU + velocity (OCM) + appearance | Yes (pluggable)    |
+| [SORT](https://arxiv.org/abs/1602.00763)         | IoU + Kalman filter               | No                 |
 
 ## Features
 
 - 🚀 **Native Rust Core** Blazingly fast tracking (< 1ms/frame for ByteTrack) with full memory safety
 - 🐍 **Python Bindings** First-class `pip install trackforge` support via PyO3
-- 🎯 **Multi-Algorithm** ByteTrack, OC-SORT, DeepSORT, and SORT with a unified API
+- 🎯 **Multi-Algorithm** ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, and SORT with a unified API
 - 🔌 **Pluggable Re-ID** DeepSORT's appearance extractor is a trait; plug in any feature model
 - 📐 **Generic Kalman Filter** Configurable position/velocity weighting, gating distance computation
 
@@ -136,6 +137,32 @@ for track_id, tlwh, score, class_id in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 
+### Python - Deep OC-SORT
+
+```python
+from trackforge import DEEPOCSORT
+
+tracker = DEEPOCSORT(
+    max_age=30,
+    min_hits=3,
+    iou_threshold=0.3,
+    delta_t=3,
+    inertia=0.2,
+    appearance_weight=0.5,
+    max_cosine_distance=0.2,
+    nn_budget=100,
+)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
+
+# Pass embeddings for appearance-aware tracking, or omit them for motion only.
+tracks = tracker.update(detections, embeddings)
+
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
 ### Rust - ByteTrack
 
 ```rust
@@ -185,6 +212,21 @@ let detections = vec![
 ];
 
 let tracks = tracker.update(detections);
+
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+### Rust - Deep OC-SORT
+
+```rust,ignore
+use trackforge::trackers::deep_ocsort::DeepOcSort;
+
+// `extractor` implements AppearanceExtractor (plug in any Re-ID model).
+let mut tracker = DeepOcSort::new(extractor, 30, 3, 0.3, 3, 0.2, 0.5, 0.2, 100);
+
+let tracks = tracker.update(&image, detections)?;
 
 for t in tracks {
     println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
@@ -353,6 +395,13 @@ also cite the paper for the tracker you use:
   title={Observation-Centric SORT: Rethinking SORT for Robust Multi-Object Tracking},
   author={Cao, Jinkun and Pang, Jiangmiao and Weng, Xinshuo and Khirodkar, Rawal and Kitani, Kris},
   booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  year={2023}
+}
+
+@inproceedings{maggiolino2023deepocsort,
+  title={Deep OC-SORT: Multi-Pedestrian Tracking by Adaptive Re-Identification},
+  author={Maggiolino, Gerard and Ahmad, Adnan and Cao, Jinkun and Kitani, Kris},
+  booktitle={IEEE International Conference on Image Processing (ICIP)},
   year={2023}
 }
 ```

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,5 +8,6 @@
   - [ByteTrack](./trackers/byte_track.md)
   - [OC-SORT](./trackers/ocsort.md)
   - [DeepSORT](./trackers/deepsort.md)
+  - [Deep OC-SORT](./trackers/deep_ocsort.md)
 - [Parameters](./parameters.md)
 - [Examples](./examples.md)

--- a/book/src/trackers/deep_ocsort.md
+++ b/book/src/trackers/deep_ocsort.md
@@ -1,0 +1,55 @@
+# Deep OC-SORT
+
+**Deep OC-SORT** ([arXiv 2302.11813](https://arxiv.org/abs/2302.11813), ICIP 2023). Extends OC-SORT
+with appearance, blending a Re-ID embedding cost into the motion association:
+
+- **OCM** adds a velocity direction-consistency bonus to the IoU before matching.
+- **ORU** replays interpolated observations to correct the Kalman filter after a track is
+  re-associated following a gap.
+- **Appearance** adds a cosine distance to each track's feature gallery. The appearance weight
+  scales with detector confidence (dynamic appearance) and is gated by `max_cosine_distance`.
+
+With `appearance_weight = 0` the association reduces to plain OC-SORT, so the appearance term is a
+strict add-on. This is a clean-room implementation of the motion and appearance association; it does
+not include camera motion compensation.
+
+```python
+from trackforge import DEEPOCSORT
+
+tracker = DEEPOCSORT(max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2,
+                     appearance_weight=0.5, max_cosine_distance=0.2, nn_budget=100)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
+tracks = tracker.update(detections, embeddings)
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
+## Parameters
+
+| Parameter             | Default | Description                                                |
+| --------------------- | ------- | ---------------------------------------------------------- |
+| `max_age`             | 30      | Frames to keep a lost track alive before deletion          |
+| `min_hits`            | 3       | Consecutive matched frames required to confirm a track     |
+| `iou_threshold`       | 0.3     | Minimum IoU to associate a detection with a track          |
+| `delta_t`             | 3       | Observation window (frames) used to compute velocity (OCM) |
+| `inertia`             | 0.2     | Weight of the direction-consistency cost bonus (OCM)       |
+| `appearance_weight`   | 0.5     | Blend weight of the appearance cost, scaled by det. score  |
+| `max_cosine_distance` | 0.2     | Maximum cosine distance for the appearance term to apply   |
+| `nn_budget`           | 100     | Maximum appearance features stored per track               |
+
+**Tuning:** raise `appearance_weight` when the Re-ID model is reliable and identities matter; lower
+it (toward 0) to fall back to OC-SORT motion. Tighten `max_cosine_distance` to only trust strong
+appearance matches. The motion parameters behave as in OC-SORT.
+
+## Citation
+
+```bibtex
+@inproceedings{maggiolino2023deepocsort,
+  title={Deep OC-SORT: Multi-Pedestrian Tracking by Adaptive Re-Identification},
+  author={Maggiolino, Gerard and Ahmad, Adnan and Cao, Jinkun and Kitani, Kris},
+  booktitle={IEEE International Conference on Image Processing (ICIP)},
+  year={2023}
+}
+```

--- a/book/src/trackers/deep_ocsort.md
+++ b/book/src/trackers/deep_ocsort.md
@@ -8,10 +8,13 @@ with appearance, blending a Re-ID embedding cost into the motion association:
   re-associated following a gap.
 - **Appearance** adds a cosine distance to each track's feature gallery. The appearance weight
   scales with detector confidence (dynamic appearance) and is gated by `max_cosine_distance`.
+- **Camera motion compensation** warps track predictions by a caller-supplied affine transform
+  before association, for moving-camera footage.
 
 With `appearance_weight = 0` the association reduces to plain OC-SORT, so the appearance term is a
-strict add-on. This is a clean-room implementation of the motion and appearance association; it does
-not include camera motion compensation.
+strict add-on. This is a clean-room implementation. CMC is applied from a transform you supply (for
+example estimated with OpenCV); the tracker does not estimate camera motion itself, which keeps the
+core free of heavy dependencies. Pass the affine as `[a, b, tx, c, d, ty]` to `update`.
 
 ```python
 from trackforge import DEEPOCSORT

--- a/book/src/trackers/index.md
+++ b/book/src/trackers/index.md
@@ -1,15 +1,16 @@
 # Trackers
 
-All four trackers share the same Kalman filter and the same detection input, and differ only in how
+All trackers share the same Kalman filter and the same detection input, and differ only in how
 they associate detections to existing tracks. Pick based on your scene and whether you have a Re-ID
 model.
 
-| Tracker                      | Appearance       | Matching             | When to use                                                 |
-| ---------------------------- | ---------------- | -------------------- | ----------------------------------------------------------- |
-| [SORT](./sort.md)            | None             | IoU                  | Simple scenes, highest speed, no occlusions                 |
-| [ByteTrack](./byte_track.md) | None             | IoU (two-stage)      | Crowded scenes, low-confidence detections, short occlusions |
-| [OC-SORT](./ocsort.md)       | None             | IoU + velocity (OCM) | Frequent brief occlusions, no Re-ID available               |
-| [DeepSORT](./deepsort.md)    | Re-ID embeddings | Appearance + IoU     | Long occlusions, dense crowds, identity-sensitive cases     |
+| Tracker                          | Appearance       | Matching                    | When to use                                                 |
+| -------------------------------- | ---------------- | --------------------------- | ----------------------------------------------------------- |
+| [SORT](./sort.md)                | None             | IoU                         | Simple scenes, highest speed, no occlusions                 |
+| [ByteTrack](./byte_track.md)     | None             | IoU (two-stage)             | Crowded scenes, low-confidence detections, short occlusions |
+| [OC-SORT](./ocsort.md)           | None             | IoU + velocity (OCM)        | Frequent brief occlusions, no Re-ID available               |
+| [DeepSORT](./deepsort.md)        | Re-ID embeddings | Appearance + IoU            | Long occlusions, dense crowds, identity-sensitive cases     |
+| [Deep OC-SORT](./deep_ocsort.md) | Re-ID embeddings | IoU + velocity + appearance | Occlusions where Re-ID helps recover identities             |
 
 The Kalman filter uses an 8-dimensional state `[x, y, a, h, vx, vy, va, vh]`, where `(x, y)` is the
 box centre, `a` is the aspect ratio, and `h` is the height. Detections in `[x, y, w, h]` (top-left)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@
 - [ByteTrack](https://arxiv.org/abs/2110.06864)
 - [OC-SORT](https://arxiv.org/abs/2203.14360)
 - [DeepSORT](https://arxiv.org/abs/1703.07402)
+- [Deep OC-SORT](https://arxiv.org/abs/2302.11813)
 - Python bindings and PyPI package
 - Rust and Python examples
 
@@ -16,15 +17,14 @@ Every tracker ships for both Python and Rust and is tested in both.
 These build on the shared `utils::kalman`, `utils::geometry`, and `utils::assignment` cores, so
 most of the work is the association logic specific to each method.
 
-| Tracker      | Builds on                               | Paper                                          | Reference                                                                         |
-| ------------ | --------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
-| BoT-SORT     | ByteTrack + Re-ID + camera motion       | [2206.14651](https://arxiv.org/abs/2206.14651) | [NirAharon/BoT-SORT](https://github.com/NirAharon/BoT-SORT)                       |
-| Deep-OC-SORT | OC-SORT + appearance                    | [2302.11813](https://arxiv.org/abs/2302.11813) | [GerardMaggiolino/Deep-OC-SORT](https://github.com/GerardMaggiolino/Deep-OC-SORT) |
-| StrongSORT   | DeepSORT + stronger Re-ID               | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)                       |
-| StrongSORT++ | StrongSORT + camera motion (AFLink/GSI) | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)                       |
-| TrackTrack   | Track-centric online association        | [CVPR 2025](https://arxiv.org/abs/2504.20083)  | [kamkyu94/TrackTrack](https://github.com/kamkyu94/TrackTrack)                     |
-| FastTracker  | Lightweight real-time association       | [2507.06310](https://arxiv.org/abs/2507.06310) | upstream reference                                                                |
-| Norfair      | Distance-based, detector-agnostic       | -                                              | [tryolabs/norfair](https://github.com/tryolabs/norfair)                           |
+| Tracker      | Builds on                               | Paper                                          | Reference                                                     |
+| ------------ | --------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
+| BoT-SORT     | ByteTrack + Re-ID + camera motion       | [2206.14651](https://arxiv.org/abs/2206.14651) | [NirAharon/BoT-SORT](https://github.com/NirAharon/BoT-SORT)   |
+| StrongSORT   | DeepSORT + stronger Re-ID               | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)   |
+| StrongSORT++ | StrongSORT + camera motion (AFLink/GSI) | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)   |
+| TrackTrack   | Track-centric online association        | [CVPR 2025](https://arxiv.org/abs/2504.20083)  | [kamkyu94/TrackTrack](https://github.com/kamkyu94/TrackTrack) |
+| FastTracker  | Lightweight real-time association       | [2507.06310](https://arxiv.org/abs/2507.06310) | upstream reference                                            |
+| Norfair      | Distance-based, detector-agnostic       | -                                              | [tryolabs/norfair](https://github.com/tryolabs/norfair)       |
 
 ## Exploring
 

--- a/python/trackforge.pyi
+++ b/python/trackforge.pyi
@@ -1,6 +1,6 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
-__all__ = ["BYTETRACK", "SORT", "OCSORT", "DEEPSORT"]
+__all__ = ["BYTETRACK", "SORT", "OCSORT", "DEEPSORT", "DEEPOCSORT"]
 
 class BYTETRACK:
     """
@@ -203,4 +203,5 @@ class DEEPOCSORT:
         self,
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]] = ...,
+        camera_motion: Optional[List[float]] = ...,
     ) -> List[Tuple[int, List[float], float, int]]: ...

--- a/python/trackforge.pyi
+++ b/python/trackforge.pyi
@@ -152,3 +152,55 @@ class DEEPSORT:
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]],
     ) -> List[Tuple[int, List[float], float, int]]: ...
+
+class DEEPOCSORT:
+    """
+    Deep OC-SORT tracker: OC-SORT motion with appearance association.
+
+    Blends a cosine distance to a per-track feature gallery into the OC-SORT
+    motion cost. Pass embeddings for appearance-aware tracking, or omit them to
+    track on motion only.
+
+    **Usage Example:**
+
+    ```python
+    from trackforge import DEEPOCSORT
+
+    tracker = DEEPOCSORT(
+        max_age=30,
+        min_hits=3,
+        iou_threshold=0.3,
+        delta_t=3,
+        inertia=0.2,
+        appearance_weight=0.5,
+        max_cosine_distance=0.2,
+        nn_budget=100,
+    )
+
+    detections = [
+        ([100.0, 100.0, 50.0, 100.0], 0.9, 0),
+    ]
+    embeddings = [[0.1, 0.2, 0.3]]
+
+    tracks = tracker.update(detections, embeddings)
+    for track_id, box, score, class_id in tracks:
+        print(f"Track ID: {track_id}, Box: {box}")
+    ```
+    """
+
+    def __init__(
+        self,
+        max_age: int = 30,
+        min_hits: int = 3,
+        iou_threshold: float = 0.3,
+        delta_t: int = 3,
+        inertia: float = 0.2,
+        appearance_weight: float = 0.5,
+        max_cosine_distance: float = 0.2,
+        nn_budget: int = 100,
+    ) -> None: ...
+    def update(
+        self,
+        detections: List[Tuple[List[float], float, int]],
+        embeddings: List[List[float]] = ...,
+    ) -> List[Tuple[int, List[float], float, int]]: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! Trackforge is a unified, high-performance computer vision tracking library implemented in
 //! Rust and exposed as a Python package via PyO3.
 //!
-//! It provides four production-ready multi-object tracking algorithms built on a shared
+//! It provides five production-ready multi-object tracking algorithms built on a shared
 //! 8-dimensional Kalman filter with state `[x, y, a, h, vx, vy, va, vh]`, where `(x, y)`
 //! is the bounding-box centre, `a` the aspect ratio, and `h` the height.
 //!
@@ -21,6 +21,7 @@
 //! | [`byte_track`] | None | IoU two-stage | Crowded scenes, low-confidence detections |
 //! | [`ocsort`] | None | IoU + velocity correction | Scenes with frequent occlusions |
 //! | [`deepsort`] | Re-ID embeddings | Appearance + IoU | Long occlusions, dense crowds |
+//! | [`deep_ocsort`] | Re-ID embeddings | IoU + velocity + appearance | Occlusions with re-identification |
 //!
 //! # SORT
 //!
@@ -126,10 +127,36 @@
 //! }
 //! ```
 //!
+//! # Deep OC-SORT
+//!
+//! Extends OC-SORT with an appearance term: a cosine distance to a per-track feature
+//! gallery is blended into the motion cost, scaled by detector confidence. Like
+//! DeepSORT it needs an [`AppearanceExtractor`], or embeddings passed directly.
+//!
+//! ```rust,ignore
+//! use trackforge::trackers::deep_ocsort::DeepOcSort;
+//!
+//! // extractor implements AppearanceExtractor (plug in any Re-ID model).
+//! // max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2,
+//! // appearance_weight=0.5, max_cosine_distance=0.2, nn_budget=100
+//! let mut tracker = DeepOcSort::new(extractor, 30, 3, 0.3, 3, 0.2, 0.5, 0.2, 100);
+//!
+//! let frame = image::DynamicImage::new_rgb8(640, 480);
+//! let detections = vec![
+//!     (trackforge::types::BoundingBox::new(100.0, 100.0, 50.0, 100.0), 0.9, 0),
+//! ];
+//!
+//! let tracks = tracker.update(&frame, detections).unwrap();
+//! for t in &tracks {
+//!     println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+//! }
+//! ```
+//!
 //! [`sort`]: trackers::sort
 //! [`byte_track`]: trackers::byte_track
 //! [`ocsort`]: trackers::ocsort
 //! [`deepsort`]: trackers::deepsort
+//! [`deep_ocsort`]: trackers::deep_ocsort
 //! [`AppearanceExtractor`]: traits::AppearanceExtractor
 
 pub mod trackers;
@@ -148,5 +175,6 @@ fn trackforge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<trackers::sort::PySort>()?;
     m.add_class::<trackers::deepsort::python::PyDeepSort>()?;
     m.add_class::<trackers::ocsort::PyOcSort>()?;
+    m.add_class::<trackers::deep_ocsort::python::PyDeepOcSort>()?;
     Ok(())
 }

--- a/src/trackers/common/cmc.rs
+++ b/src/trackers/common/cmc.rs
@@ -1,0 +1,159 @@
+//! Camera motion compensation (CMC) shared across trackers.
+//!
+//! A [`CameraMotion`] is a 2x3 affine transform that maps coordinates from the
+//! previous frame into the current frame. Callers estimate it however they like
+//! (for example image registration with OpenCV in a demo) and pass it to a
+//! tracker's `update`; the tracker warps its predicted track states so motion
+//! association stays valid under a moving camera. Trackers that consume it (Deep
+//! OC-SORT today, BoT-SORT and StrongSORT++ in the future) all apply it the same
+//! way through [`super::KalmanTrack::apply_camera_motion`].
+
+use crate::utils::kalman::{CovarianceMatrix, MeasurementVector, StateVector};
+
+/// A 2x3 affine camera-motion transform `[[a, b, tx], [c, d, ty]]`.
+///
+/// Maps a previous-frame point `(x, y)` to `(a*x + b*y + tx, c*x + d*y + ty)`.
+/// The default is the identity (no camera motion).
+#[derive(Debug, Clone, Copy)]
+pub struct CameraMotion {
+    /// Row 0 of the linear part.
+    pub a: f32,
+    pub b: f32,
+    /// Horizontal translation.
+    pub tx: f32,
+    /// Row 1 of the linear part.
+    pub c: f32,
+    pub d: f32,
+    /// Vertical translation.
+    pub ty: f32,
+}
+
+impl Default for CameraMotion {
+    fn default() -> Self {
+        Self::identity()
+    }
+}
+
+impl CameraMotion {
+    /// Build a transform from the six affine coefficients.
+    pub fn new(a: f32, b: f32, tx: f32, c: f32, d: f32, ty: f32) -> Self {
+        Self { a, b, tx, c, d, ty }
+    }
+
+    /// The identity transform (no camera motion).
+    pub fn identity() -> Self {
+        Self::new(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+    }
+
+    /// Whether this transform is the identity, so application can be skipped.
+    pub fn is_identity(&self) -> bool {
+        self.a == 1.0
+            && self.b == 0.0
+            && self.tx == 0.0
+            && self.c == 0.0
+            && self.d == 1.0
+            && self.ty == 0.0
+    }
+
+    /// Uniform scale factor implied by the linear part (`sqrt(|det|)`).
+    fn scale(&self) -> f32 {
+        (self.a * self.d - self.b * self.c).abs().sqrt()
+    }
+
+    /// 8x8 linear warp matrix for the Kalman state `[x, y, a, h, vx, vy, va, vh]`.
+    ///
+    /// Applies the 2x2 linear part to the position `(x, y)` and velocity
+    /// `(vx, vy)` blocks, the uniform scale to the height `h` and its velocity
+    /// `vh`, and leaves the aspect ratio `a` and its velocity unchanged.
+    fn linear_state_matrix(&self) -> CovarianceMatrix {
+        let scale = self.scale();
+        let mut r = CovarianceMatrix::identity();
+        r[(0, 0)] = self.a;
+        r[(0, 1)] = self.b;
+        r[(1, 0)] = self.c;
+        r[(1, 1)] = self.d;
+        r[(3, 3)] = scale;
+        r[(4, 4)] = self.a;
+        r[(4, 5)] = self.b;
+        r[(5, 4)] = self.c;
+        r[(5, 5)] = self.d;
+        r[(7, 7)] = scale;
+        r
+    }
+
+    /// Warp a Kalman mean and covariance in place.
+    pub fn apply_state(&self, mean: &mut StateVector, covariance: &mut CovarianceMatrix) {
+        let r = self.linear_state_matrix();
+        let mut warped = r * *mean;
+        warped[0] += self.tx;
+        warped[1] += self.ty;
+        *mean = warped;
+        *covariance = r * *covariance * r.transpose();
+    }
+
+    /// Warp an XYAH observation `[cx, cy, aspect, height]` in place.
+    pub fn apply_observation(&self, obs: &mut MeasurementVector) {
+        let (cx, cy) = (obs[0], obs[1]);
+        obs[0] = self.a * cx + self.b * cy + self.tx;
+        obs[1] = self.c * cx + self.d * cy + self.ty;
+        obs[3] *= self.scale();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_identity() {
+        assert!(CameraMotion::default().is_identity());
+    }
+
+    #[test]
+    fn identity_is_a_no_op() {
+        let cmc = CameraMotion::identity();
+        assert!(cmc.is_identity());
+        let mut mean = StateVector::from_vec(vec![10.0, 20.0, 0.5, 40.0, 1.0, 2.0, 0.0, 0.0]);
+        let original = mean;
+        let mut cov = CovarianceMatrix::identity();
+        cmc.apply_state(&mut mean, &mut cov);
+        assert!((mean - original).norm() < 1e-5);
+    }
+
+    #[test]
+    fn translation_shifts_position_not_velocity() {
+        let cmc = CameraMotion::new(1.0, 0.0, 5.0, 0.0, 1.0, -3.0);
+        assert!(!cmc.is_identity());
+        let mut mean = StateVector::from_vec(vec![10.0, 20.0, 0.5, 40.0, 1.0, 2.0, 0.0, 0.0]);
+        let mut cov = CovarianceMatrix::identity();
+        cmc.apply_state(&mut mean, &mut cov);
+        assert!((mean[0] - 15.0).abs() < 1e-5);
+        assert!((mean[1] - 17.0).abs() < 1e-5);
+        // Pure translation leaves velocity untouched.
+        assert!((mean[4] - 1.0).abs() < 1e-5);
+        assert!((mean[5] - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn scale_grows_height_and_velocity() {
+        // 2x uniform scale: positions and height double, velocity scales linearly.
+        let cmc = CameraMotion::new(2.0, 0.0, 0.0, 0.0, 2.0, 0.0);
+        let mut mean = StateVector::from_vec(vec![10.0, 20.0, 0.5, 40.0, 1.0, 2.0, 0.0, 3.0]);
+        let mut cov = CovarianceMatrix::identity();
+        cmc.apply_state(&mut mean, &mut cov);
+        assert!((mean[0] - 20.0).abs() < 1e-5);
+        assert!((mean[3] - 80.0).abs() < 1e-5); // height doubled
+        assert!((mean[4] - 2.0).abs() < 1e-5); // vx doubled
+        assert!((mean[7] - 6.0).abs() < 1e-5); // vh doubled
+    }
+
+    #[test]
+    fn observation_is_warped() {
+        let cmc = CameraMotion::new(1.0, 0.0, 4.0, 0.0, 1.0, 2.0);
+        let mut obs = MeasurementVector::from_vec(vec![10.0, 20.0, 0.5, 40.0]);
+        cmc.apply_observation(&mut obs);
+        assert!((obs[0] - 14.0).abs() < 1e-5);
+        assert!((obs[1] - 22.0).abs() < 1e-5);
+        assert!((obs[3] - 40.0).abs() < 1e-5);
+    }
+}

--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -2,7 +2,12 @@
 //!
 //! [`TrackState`] is the common confirm/delete lifecycle used by the IoU and
 //! appearance trackers, and [`KalmanTrack`] wraps the per-track Kalman state with
-//! the predict/update mechanics they all repeat.
+//! the predict/update mechanics they all repeat. [`cmc`] holds the shared camera
+//! motion compensation transform.
+
+pub mod cmc;
+
+pub use cmc::CameraMotion;
 
 use crate::utils::geometry::xyah_to_tlwh;
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
@@ -55,5 +60,11 @@ impl KalmanTrack {
         let (mean, covariance) = kf.update(&self.mean, &self.covariance, measurement);
         self.mean = mean;
         self.covariance = covariance;
+    }
+
+    /// Warp the Kalman state by a camera motion transform and return the new TLWH box.
+    pub fn apply_camera_motion(&mut self, cmc: &CameraMotion) -> [f32; 4] {
+        cmc.apply_state(&mut self.mean, &mut self.covariance);
+        xyah_to_tlwh(&self.mean)
     }
 }

--- a/src/trackers/deep_ocsort/README.md
+++ b/src/trackers/deep_ocsort/README.md
@@ -17,16 +17,20 @@ Deep OC-SORT extends OC-SORT by adding an appearance term to the association:
   with the motion cost. The appearance weight scales with detector confidence (dynamic
   appearance) and is gated by `max_cosine_distance`. With `appearance_weight = 0` the
   association reduces to plain OC-SORT.
+- **Camera motion compensation (CMC)** warps track predictions by a caller-supplied
+  affine transform before association, for moving-camera footage. The transform is
+  shared `common::cmc` infrastructure reused by other trackers.
 
-This is a clean-room implementation focused on the motion (OCM/ORU) and adaptive
-appearance association; it does not include camera motion compensation.
+This is a clean-room implementation. The tracker applies a camera-motion transform but
+does not estimate it: the caller supplies the affine (for example from image
+registration), keeping the core free of heavy computer-vision dependencies.
 
 ## Builds on
 
 - `utils::kalman` - the shared 8-dimensional Kalman filter
 - `utils::geometry` - `iou_batch`, `tlwh_to_xyah`, `xyah_to_tlwh`
 - `utils::assignment` - `greedy_match`
-- `trackers::common` - `KalmanTrack` and `TrackState`
+- `trackers::common` - `KalmanTrack`, `TrackState`, and `CameraMotion` (CMC)
 - `trackers::deepsort` - `NearestNeighborDistanceMetric` for the cosine feature gallery
 
 ## Parameters
@@ -74,6 +78,12 @@ tracker = DEEPOCSORT(
 detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
 tracks = tracker.update(detections, embeddings)
+
+# Moving camera: pass a [a, b, tx, c, d, ty] affine mapping the previous frame
+# to the current one (estimate it however you like, e.g. with OpenCV).
+camera_motion = [1.0, 0.0, 12.0, 0.0, 1.0, -4.0]
+tracks = tracker.update(detections, embeddings, camera_motion)
+
 for track_id, tlwh, score, class_id in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```

--- a/src/trackers/deep_ocsort/README.md
+++ b/src/trackers/deep_ocsort/README.md
@@ -1,0 +1,96 @@
+# Deep OC-SORT: Observation-Centric SORT with appearance
+
+This module implements the Deep OC-SORT algorithm.
+
+> **Deep OC-SORT: Multi-Pedestrian Tracking by Adaptive Re-Identification**
+> Gerard Maggiolino, Adnan Ahmad, Jinkun Cao, Kris Kitani
+> [arXiv:2302.11813](https://arxiv.org/abs/2302.11813)
+
+## Algorithm overview
+
+Deep OC-SORT extends OC-SORT by adding an appearance term to the association:
+
+- **OCM** adds a velocity direction-consistency bonus to the IoU before matching.
+- **ORU** replays interpolated observations to correct the Kalman filter after a track
+  is re-associated following a gap.
+- **Appearance** association blends a cosine distance to each track's feature gallery
+  with the motion cost. The appearance weight scales with detector confidence (dynamic
+  appearance) and is gated by `max_cosine_distance`. With `appearance_weight = 0` the
+  association reduces to plain OC-SORT.
+
+This is a clean-room implementation focused on the motion (OCM/ORU) and adaptive
+appearance association; it does not include camera motion compensation.
+
+## Builds on
+
+- `utils::kalman` - the shared 8-dimensional Kalman filter
+- `utils::geometry` - `iou_batch`, `tlwh_to_xyah`, `xyah_to_tlwh`
+- `utils::assignment` - `greedy_match`
+- `trackers::common` - `KalmanTrack` and `TrackState`
+- `trackers::deepsort` - `NearestNeighborDistanceMetric` for the cosine feature gallery
+
+## Parameters
+
+| Parameter             | Default | Description                                                |
+| --------------------- | ------- | ---------------------------------------------------------- |
+| `max_age`             | 30      | Frames a lost track survives before deletion               |
+| `min_hits`            | 3       | Consecutive matches required to confirm a track            |
+| `iou_threshold`       | 0.3     | Minimum IoU to associate a detection with a track          |
+| `delta_t`             | 3       | Observation window (frames) used to compute velocity (OCM) |
+| `inertia`             | 0.2     | Weight of the direction-consistency cost bonus (OCM)       |
+| `appearance_weight`   | 0.5     | Blend weight of the appearance cost, scaled by det. score  |
+| `max_cosine_distance` | 0.2     | Maximum cosine distance for the appearance term to apply   |
+| `nn_budget`           | 100     | Maximum appearance features stored per track               |
+
+## Rust API
+
+```rust,ignore
+use trackforge::trackers::deep_ocsort::DeepOcSort;
+
+// `extractor` implements the AppearanceExtractor trait (plug in any Re-ID model).
+let mut tracker = DeepOcSort::new(extractor, 30, 3, 0.3, 3, 0.2, 0.5, 0.2, 100);
+let tracks = tracker.update(&image, detections)?;
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+## Python API
+
+```python
+from trackforge import DEEPOCSORT
+
+tracker = DEEPOCSORT(
+    max_age=30,
+    min_hits=3,
+    iou_threshold=0.3,
+    delta_t=3,
+    inertia=0.2,
+    appearance_weight=0.5,
+    max_cosine_distance=0.2,
+    nn_budget=100,
+)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
+tracks = tracker.update(detections, embeddings)
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
+## Credit
+
+Clean-room Rust implementation of the algorithm described in the paper above. Original
+reference implementation:
+[GerardMaggiolino/Deep-OC-SORT](https://github.com/GerardMaggiolino/Deep-OC-SORT).
+
+## Citation
+
+```bibtex
+@inproceedings{maggiolino2023deepocsort,
+  title={Deep OC-SORT: Multi-Pedestrian Tracking by Adaptive Re-Identification},
+  author={Maggiolino, Gerard and Ahmad, Adnan and Cao, Jinkun and Kitani, Kris},
+  booktitle={IEEE International Conference on Image Processing (ICIP)},
+  year={2023}
+}
+```

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -1,0 +1,194 @@
+#![doc = include_str!("README.md")]
+
+mod track;
+mod tracker;
+
+#[cfg(feature = "python")]
+pub mod python;
+
+pub use track::DeepOcSortTrack;
+pub use tracker::DeepOcSortTracker;
+
+use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
+use crate::traits::AppearanceExtractor;
+use crate::types::BoundingBox;
+use image::DynamicImage;
+use std::error::Error;
+
+/// Build the inner Deep OC-SORT tracker shared by the Rust and Python constructors.
+#[allow(clippy::too_many_arguments)]
+fn build_tracker(
+    max_age: usize,
+    min_hits: usize,
+    iou_threshold: f32,
+    delta_t: usize,
+    inertia: f32,
+    appearance_weight: f32,
+    max_cosine_distance: f32,
+    nn_budget: usize,
+) -> DeepOcSortTracker {
+    let metric =
+        NearestNeighborDistanceMetric::new(Metric::Cosine, max_cosine_distance, Some(nn_budget));
+    DeepOcSortTracker::new(
+        max_age,
+        min_hits,
+        iou_threshold,
+        delta_t,
+        inertia,
+        appearance_weight,
+        max_cosine_distance,
+        metric,
+    )
+}
+
+/// Deep OC-SORT tracker.
+///
+/// Wraps the association core with an [`AppearanceExtractor`] so the caller can pass a
+/// frame and detections and have the embeddings produced internally. To pass
+/// embeddings directly, drive [`DeepOcSortTracker`] instead.
+pub struct DeepOcSort<E: AppearanceExtractor> {
+    extractor: E,
+    tracker: DeepOcSortTracker,
+}
+
+impl<E: AppearanceExtractor> DeepOcSort<E> {
+    /// Create a new Deep OC-SORT tracker.
+    ///
+    /// # Arguments
+    /// * `extractor` - The appearance feature extractor.
+    /// * `max_age` - Frames a lost track survives before deletion. Default: 30.
+    /// * `min_hits` - Consecutive matches required to confirm a track. Default: 3.
+    /// * `iou_threshold` - Minimum IoU to associate a detection with a track. Default: 0.3.
+    /// * `delta_t` - Observation window for velocity computation. Default: 3.
+    /// * `inertia` - Weight for the OCM direction-consistency bonus. Default: 0.2.
+    /// * `appearance_weight` - Blend weight of the appearance cost. Default: 0.5.
+    /// * `max_cosine_distance` - Gate for the appearance term. Default: 0.2.
+    /// * `nn_budget` - Maximum appearance features stored per track. Default: 100.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        extractor: E,
+        max_age: usize,
+        min_hits: usize,
+        iou_threshold: f32,
+        delta_t: usize,
+        inertia: f32,
+        appearance_weight: f32,
+        max_cosine_distance: f32,
+        nn_budget: usize,
+    ) -> Self {
+        let tracker = build_tracker(
+            max_age,
+            min_hits,
+            iou_threshold,
+            delta_t,
+            inertia,
+            appearance_weight,
+            max_cosine_distance,
+            nn_budget,
+        );
+        Self { extractor, tracker }
+    }
+
+    /// Create a tracker with the default parameters.
+    pub fn new_default(extractor: E) -> Self {
+        Self::new(extractor, 30, 3, 0.3, 3, 0.2, 0.5, 0.2, 100)
+    }
+
+    /// Update the tracker with a frame and its detections.
+    ///
+    /// Extracts an appearance embedding per detection, then runs the association.
+    /// Returns the confirmed tracks matched in this frame.
+    pub fn update(
+        &mut self,
+        image: &DynamicImage,
+        detections: Vec<(BoundingBox, f32, i64)>,
+    ) -> Result<Vec<DeepOcSortTrack>, Box<dyn Error>> {
+        let bboxes: Vec<BoundingBox> = detections.iter().map(|(bbox, _, _)| *bbox).collect();
+        let embeddings = if bboxes.is_empty() {
+            Vec::new()
+        } else {
+            self.extractor.extract(image, &bboxes)?
+        };
+
+        let det_tuples: Vec<([f32; 4], f32, i64)> = detections
+            .iter()
+            .map(|(b, score, class_id)| ([b.x, b.y, b.width, b.height], *score, *class_id))
+            .collect();
+
+        Ok(self.tracker.update(&det_tuples, &embeddings))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
+        ([x, y, w, h], s, 0)
+    }
+
+    #[test]
+    fn confirms_after_min_hits() {
+        let mut tracker = build_tracker(30, 3, 0.3, 3, 0.2, 0.5, 0.2, 100);
+        for _ in 0..2 {
+            assert!(
+                tracker
+                    .update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])
+                    .is_empty()
+            );
+        }
+        let tracks = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, 1);
+    }
+
+    #[test]
+    fn empty_detections_return_no_tracks() {
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
+        assert!(tracker.update(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn zero_weight_matches_without_appearance() {
+        // appearance_weight = 0 reduces to OC-SORT; embeddings are still accepted.
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        let emb = vec![vec![1.0, 0.0]];
+        let t1 = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &emb);
+        assert_eq!(t1.len(), 1);
+        let id = t1[0].track_id;
+        let t2 = tracker.update(&[det(103.0, 100.0, 50.0, 100.0, 0.9)], &emb);
+        assert_eq!(t2.len(), 1);
+        assert_eq!(t2[0].track_id, id);
+    }
+
+    #[test]
+    fn appearance_keeps_track_id_across_frames() {
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.5, 0.3, 100);
+        let emb = vec![vec![1.0, 0.0, 0.0]];
+        let t1 = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &emb);
+        let id = t1[0].track_id;
+        let t2 = tracker.update(&[det(104.0, 100.0, 50.0, 100.0, 0.9)], &emb);
+        assert_eq!(t2.len(), 1);
+        assert_eq!(t2[0].track_id, id);
+    }
+
+    struct MockExtractor;
+    impl AppearanceExtractor for MockExtractor {
+        fn extract(
+            &mut self,
+            _image: &DynamicImage,
+            bboxes: &[BoundingBox],
+        ) -> Result<Vec<Vec<f32>>, Box<dyn Error>> {
+            Ok(vec![vec![1.0, 0.0]; bboxes.len()])
+        }
+    }
+
+    #[test]
+    fn extractor_wrapper_confirms_track() {
+        let mut tracker = DeepOcSort::new(MockExtractor, 30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
+        let image = DynamicImage::new_rgb8(200, 200);
+        let dets = vec![(BoundingBox::new(10.0, 10.0, 20.0, 40.0), 0.9, 0)];
+        let tracks = tracker.update(&image, dets).unwrap();
+        assert_eq!(tracks.len(), 1);
+    }
+}

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -9,6 +9,7 @@ pub mod python;
 pub use track::DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
+use crate::trackers::common::CameraMotion;
 use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
 use crate::traits::AppearanceExtractor;
 use crate::types::BoundingBox;
@@ -103,6 +104,29 @@ impl<E: AppearanceExtractor> DeepOcSort<E> {
         image: &DynamicImage,
         detections: Vec<(BoundingBox, f32, i64)>,
     ) -> Result<Vec<DeepOcSortTrack>, Box<dyn Error>> {
+        self.run(image, detections, &CameraMotion::identity())
+    }
+
+    /// Update the tracker, first warping track predictions by `camera_motion`.
+    ///
+    /// Use this on moving-camera footage; estimate the affine transform between the
+    /// previous and current frame (for example with image registration) and pass it
+    /// in. See [`CameraMotion`].
+    pub fn update_with_camera_motion(
+        &mut self,
+        image: &DynamicImage,
+        detections: Vec<(BoundingBox, f32, i64)>,
+        camera_motion: &CameraMotion,
+    ) -> Result<Vec<DeepOcSortTrack>, Box<dyn Error>> {
+        self.run(image, detections, camera_motion)
+    }
+
+    fn run(
+        &mut self,
+        image: &DynamicImage,
+        detections: Vec<(BoundingBox, f32, i64)>,
+        camera_motion: &CameraMotion,
+    ) -> Result<Vec<DeepOcSortTrack>, Box<dyn Error>> {
         let bboxes: Vec<BoundingBox> = detections.iter().map(|(bbox, _, _)| *bbox).collect();
         let embeddings = if bboxes.is_empty() {
             Vec::new()
@@ -115,7 +139,9 @@ impl<E: AppearanceExtractor> DeepOcSort<E> {
             .map(|(b, score, class_id)| ([b.x, b.y, b.width, b.height], *score, *class_id))
             .collect();
 
-        Ok(self.tracker.update(&det_tuples, &embeddings))
+        Ok(self
+            .tracker
+            .update_with_camera_motion(&det_tuples, &embeddings, camera_motion))
     }
 }
 
@@ -224,6 +250,29 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_applies_camera_motion() {
+        let mut tracker = DeepOcSort::new(MockExtractor, 30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
+        let image = DynamicImage::new_rgb8(800, 400);
+        let id = tracker
+            .update(
+                &image,
+                vec![(BoundingBox::new(100.0, 100.0, 50.0, 100.0), 0.9, 0)],
+            )
+            .unwrap()[0]
+            .track_id;
+        let cmc = CameraMotion::new(1.0, 0.0, 200.0, 0.0, 1.0, 0.0);
+        let tracks = tracker
+            .update_with_camera_motion(
+                &image,
+                vec![(BoundingBox::new(300.0, 100.0, 50.0, 100.0), 0.9, 0)],
+                &cmc,
+            )
+            .unwrap();
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
     fn wrapper_handles_empty_detections() {
         let mut tracker = DeepOcSort::new_default(MockExtractor);
         let image = DynamicImage::new_rgb8(200, 200);
@@ -283,6 +332,27 @@ mod tests {
         // Track 1 (at the origin) was deleted; the new track confirms here.
         let tracks = tracker.update(&[det(500.0, 500.0, 50.0, 100.0, 0.9)], &[]);
         assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, 2);
+    }
+
+    #[test]
+    fn camera_motion_warps_prediction_for_matching() {
+        // Establish a track, then pan the camera right by 200px so the same object
+        // appears at x=300. The warp moves the prediction with it, keeping the id.
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        let id = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        let cmc = CameraMotion::new(1.0, 0.0, 200.0, 0.0, 1.0, 0.0);
+        let tracks =
+            tracker.update_with_camera_motion(&[det(300.0, 100.0, 50.0, 100.0, 0.9)], &[], &cmc);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn without_camera_motion_a_large_shift_starts_a_new_track() {
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        let tracks = tracker.update(&[det(300.0, 100.0, 50.0, 100.0, 0.9)], &[]);
         assert_eq!(tracks[0].track_id, 2);
     }
 

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -183,6 +183,25 @@ mod tests {
         }
     }
 
+    struct FailingExtractor;
+    impl AppearanceExtractor for FailingExtractor {
+        fn extract(
+            &mut self,
+            _image: &DynamicImage,
+            _bboxes: &[BoundingBox],
+        ) -> Result<Vec<Vec<f32>>, Box<dyn Error>> {
+            Err("extraction failed".into())
+        }
+    }
+
+    #[test]
+    fn wrapper_propagates_extractor_error() {
+        let mut tracker = DeepOcSort::new_default(FailingExtractor);
+        let image = DynamicImage::new_rgb8(200, 200);
+        let dets = vec![(BoundingBox::new(10.0, 10.0, 20.0, 40.0), 0.9, 0)];
+        assert!(tracker.update(&image, dets).is_err());
+    }
+
     #[test]
     fn extractor_wrapper_confirms_track() {
         let mut tracker = DeepOcSort::new(MockExtractor, 30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
@@ -190,5 +209,98 @@ mod tests {
         let dets = vec![(BoundingBox::new(10.0, 10.0, 20.0, 40.0), 0.9, 0)];
         let tracks = tracker.update(&image, dets).unwrap();
         assert_eq!(tracks.len(), 1);
+    }
+
+    #[test]
+    fn new_default_runs_through_wrapper() {
+        let mut tracker = DeepOcSort::new_default(MockExtractor);
+        let image = DynamicImage::new_rgb8(200, 200);
+        let dets = vec![(BoundingBox::new(10.0, 10.0, 20.0, 40.0), 0.9, 0)];
+        // n_init default is 3, so confirmation needs three matched frames.
+        for _ in 0..2 {
+            assert!(tracker.update(&image, dets.clone()).unwrap().is_empty());
+        }
+        assert_eq!(tracker.update(&image, dets).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn wrapper_handles_empty_detections() {
+        let mut tracker = DeepOcSort::new_default(MockExtractor);
+        let image = DynamicImage::new_rgb8(200, 200);
+        assert!(tracker.update(&image, vec![]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn round2_rematch_and_oru_after_gap() {
+        // Build a strong rightward velocity with overlapping steps, drop two frames
+        // so the Kalman prediction overshoots well past the object, then re-detect at
+        // the last observed position. Round 1 misses; the round-2 pass on the last
+        // observation recovers the track and runs the ORU re-update.
+        // Large boxes and steps so the damped Kalman velocity still drifts the
+        // prediction off the object during the gap.
+        let mut tracker = build_tracker(20, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        for step in 0..8 {
+            let x = step as f32 * 200.0;
+            tracker.update(&[det(x, 0.0, 400.0, 100.0, 0.9)], &[]);
+        }
+        for _ in 0..4 {
+            tracker.update(&[], &[]);
+        }
+        let tracks = tracker.update(&[det(1400.0, 0.0, 400.0, 100.0, 0.9)], &[]);
+        assert!(!tracks.is_empty());
+        assert_eq!(tracks[0].track_id, 1);
+    }
+
+    #[test]
+    fn oru_runs_on_rematch_after_gap() {
+        // A track misses one frame and is re-detected at the same position. Round 1
+        // matches, and because it was lost the ORU re-update runs.
+        let mut tracker = build_tracker(10, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        let id = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        tracker.update(&[], &[]);
+        let tracks = tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn track_deleted_after_max_age() {
+        let mut tracker = build_tracker(2, 1, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        tracker.update(&[det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        for _ in 0..4 {
+            tracker.update(&[], &[]);
+        }
+        assert!(tracker.update(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn unmatched_tentative_is_deleted() {
+        // min_hits = 2 keeps the first track tentative; a far detection on the next
+        // frame leaves it unmatched, so it is dropped and a new track starts.
+        let mut tracker = build_tracker(30, 2, 0.3, 3, 0.2, 0.0, 0.2, 100);
+        tracker.update(&[det(0.0, 0.0, 50.0, 100.0, 0.9)], &[]);
+        tracker.update(&[det(500.0, 500.0, 50.0, 100.0, 0.9)], &[]);
+        // Track 1 (at the origin) was deleted; the new track confirms here.
+        let tracks = tracker.update(&[det(500.0, 500.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, 2);
+    }
+
+    #[test]
+    fn appearance_gated_when_dissimilar() {
+        // A tiny max_cosine_distance gates out a dissimilar embedding, so the match
+        // falls back to motion only and the track id persists.
+        let mut tracker = build_tracker(30, 1, 0.3, 3, 0.2, 0.5, 0.05, 100);
+        let id = tracker.update(
+            &[det(100.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![1.0, 0.0, 0.0]],
+        )[0]
+        .track_id;
+        let tracks = tracker.update(
+            &[det(103.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![0.0, 1.0, 0.0]],
+        );
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
     }
 }

--- a/src/trackers/deep_ocsort/python.rs
+++ b/src/trackers/deep_ocsort/python.rs
@@ -1,4 +1,5 @@
 use super::DeepOcSortTracker;
+use crate::trackers::common::CameraMotion;
 use pyo3::prelude::*;
 
 type PyTrackingResult = (u64, [f32; 4], f32, i64);
@@ -54,14 +55,18 @@ impl PyDeepOcSort {
     ///     detections (list): List of ([x, y, w, h], score, class_id) tuples.
     ///     embeddings (list): Appearance vectors, one per detection. Pass an empty
     ///         list to track on motion only.
+    ///     camera_motion (list, optional): Six affine coefficients
+    ///         [a, b, tx, c, d, ty] mapping the previous frame to the current one,
+    ///         for moving-camera footage. Defaults to no camera motion.
     ///
     /// Returns:
     ///     list: Confirmed tracks as (track_id, [x, y, w, h], score, class_id) tuples.
-    #[pyo3(signature = (detections, embeddings=Vec::new()))]
+    #[pyo3(signature = (detections, embeddings=Vec::new(), camera_motion=None))]
     fn update(
         &mut self,
         detections: Vec<([f32; 4], f32, i64)>,
         embeddings: Vec<Vec<f32>>,
+        camera_motion: Option<[f32; 6]>,
     ) -> PyResult<Vec<PyTrackingResult>> {
         if !embeddings.is_empty() && embeddings.len() != detections.len() {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -69,7 +74,12 @@ impl PyDeepOcSort {
             ));
         }
 
-        let tracks = self.tracker.update(&detections, &embeddings);
+        let cmc = camera_motion
+            .map(|m| CameraMotion::new(m[0], m[1], m[2], m[3], m[4], m[5]))
+            .unwrap_or_default();
+        let tracks = self
+            .tracker
+            .update_with_camera_motion(&detections, &embeddings, &cmc);
         Ok(tracks
             .into_iter()
             .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))

--- a/src/trackers/deep_ocsort/python.rs
+++ b/src/trackers/deep_ocsort/python.rs
@@ -1,0 +1,78 @@
+use super::DeepOcSortTracker;
+use pyo3::prelude::*;
+
+type PyTrackingResult = (u64, [f32; 4], f32, i64);
+
+/// Python-exposed Deep OC-SORT tracker.
+#[pyclass(name = "DEEPOCSORT")]
+pub struct PyDeepOcSort {
+    tracker: DeepOcSortTracker,
+}
+
+#[pymethods]
+impl PyDeepOcSort {
+    #[new]
+    #[pyo3(signature = (max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2, appearance_weight=0.5, max_cosine_distance=0.2, nn_budget=100))]
+    #[allow(clippy::too_many_arguments)]
+    /// Initialize the Deep OC-SORT tracker.
+    ///
+    /// Args:
+    ///     max_age (int): Frames a lost track is kept alive. Default: 30.
+    ///     min_hits (int): Consecutive matches to confirm a track. Default: 3.
+    ///     iou_threshold (float): IoU threshold for matching. Default: 0.3.
+    ///     delta_t (int): Observation window for velocity computation. Default: 3.
+    ///     inertia (float): Velocity direction-consistency weight in [0, 1]. Default: 0.2.
+    ///     appearance_weight (float): Appearance blend weight in [0, 1]. Default: 0.5.
+    ///     max_cosine_distance (float): Gate for the appearance term. Default: 0.2.
+    ///     nn_budget (int): Maximum appearance features stored per track. Default: 100.
+    fn new(
+        max_age: usize,
+        min_hits: usize,
+        iou_threshold: f32,
+        delta_t: usize,
+        inertia: f32,
+        appearance_weight: f32,
+        max_cosine_distance: f32,
+        nn_budget: usize,
+    ) -> Self {
+        let tracker = super::build_tracker(
+            max_age,
+            min_hits,
+            iou_threshold,
+            delta_t,
+            inertia,
+            appearance_weight,
+            max_cosine_distance,
+            nn_budget,
+        );
+        Self { tracker }
+    }
+
+    /// Update the tracker with detections and optional appearance embeddings.
+    ///
+    /// Args:
+    ///     detections (list): List of ([x, y, w, h], score, class_id) tuples.
+    ///     embeddings (list): Appearance vectors, one per detection. Pass an empty
+    ///         list to track on motion only.
+    ///
+    /// Returns:
+    ///     list: Confirmed tracks as (track_id, [x, y, w, h], score, class_id) tuples.
+    #[pyo3(signature = (detections, embeddings=Vec::new()))]
+    fn update(
+        &mut self,
+        detections: Vec<([f32; 4], f32, i64)>,
+        embeddings: Vec<Vec<f32>>,
+    ) -> PyResult<Vec<PyTrackingResult>> {
+        if !embeddings.is_empty() && embeddings.len() != detections.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Number of detections and embeddings must match",
+            ));
+        }
+
+        let tracks = self.tracker.update(&detections, &embeddings);
+        Ok(tracks
+            .into_iter()
+            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .collect())
+    }
+}

--- a/src/trackers/deep_ocsort/track.rs
+++ b/src/trackers/deep_ocsort/track.rs
@@ -1,0 +1,186 @@
+//! Per-track state for Deep OC-SORT: OC-SORT motion plus an appearance buffer.
+
+use crate::trackers::common::{KalmanTrack, TrackState};
+use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
+use crate::utils::kalman::{KalmanFilter, MeasurementVector};
+
+/// A single tracked object managed by Deep OC-SORT.
+///
+/// Carries the OC-SORT motion state (Kalman filter plus an observation history for
+/// OCM and ORU) and a small buffer of appearance embeddings that are flushed into
+/// the tracker's feature gallery after each matched update.
+#[derive(Debug, Clone)]
+pub struct DeepOcSortTrack {
+    /// Bounding box in TLWH (top-left x, top-left y, width, height) format.
+    pub tlwh: [f32; 4],
+    /// Detection confidence of the most recent match.
+    pub score: f32,
+    /// Class label of the most recent match.
+    pub class_id: i64,
+    /// Unique monotonically increasing track identifier.
+    pub track_id: u64,
+    /// Current lifecycle state.
+    pub state: TrackState,
+    /// Total number of detection matches over the track lifetime.
+    pub hits: usize,
+    /// Consecutive detection matches without interruption (resets on a missed frame).
+    pub hit_streak: usize,
+    /// Frames elapsed since the last detection match.
+    pub time_since_update: usize,
+    /// Total frames since track creation.
+    pub age: usize,
+
+    kalman: KalmanTrack,
+    // Circular observation history (xyah, frame_id) used for OCV and ORU.
+    observations: Vec<(MeasurementVector, usize)>,
+    // Appearance embeddings collected since the last gallery flush.
+    pending_features: Vec<Vec<f32>>,
+}
+
+impl DeepOcSortTrack {
+    pub(super) fn new(
+        tlwh: [f32; 4],
+        score: f32,
+        class_id: i64,
+        track_id: u64,
+        frame_id: usize,
+        feature: Option<Vec<f32>>,
+        kf: &KalmanFilter,
+    ) -> Self {
+        let xyah = tlwh_to_xyah(&tlwh);
+        let kalman = KalmanTrack::initiate(&xyah, kf);
+        let observations = vec![(xyah, frame_id)];
+        let pending_features = feature.into_iter().collect();
+
+        Self {
+            tlwh,
+            score,
+            class_id,
+            track_id,
+            state: TrackState::Tentative,
+            hits: 1,
+            hit_streak: 1,
+            time_since_update: 0,
+            age: 1,
+            kalman,
+            observations,
+            pending_features,
+        }
+    }
+
+    /// Kalman-predict one step forward, resetting `hit_streak` after a missed frame.
+    pub(super) fn predict(&mut self, kf: &KalmanFilter) {
+        if self.time_since_update > 0 {
+            self.hit_streak = 0;
+        }
+        self.tlwh = self.kalman.predict(kf);
+        self.age += 1;
+        self.time_since_update += 1;
+    }
+
+    /// Standard Kalman update with a matched detection in XYAH form.
+    pub(super) fn update_kf(&mut self, xyah: &MeasurementVector, kf: &KalmanFilter) {
+        self.kalman.update(xyah, kf);
+        self.tlwh = xyah_to_tlwh(&self.kalman.mean);
+    }
+
+    /// OCV: normalised `[dy, dx]` velocity direction over the last `delta_t` frames.
+    ///
+    /// Returns `None` when fewer than two observations are available.
+    pub(super) fn obs_direction(&self, delta_t: usize) -> Option<[f32; 2]> {
+        let n = self.observations.len();
+        if n < 2 {
+            return None;
+        }
+        let anchor_idx = n.saturating_sub(delta_t + 1);
+        let (obs_old, _) = &self.observations[anchor_idx];
+        let (obs_new, _) = &self.observations[n - 1];
+        let dy = obs_new[1] - obs_old[1];
+        let dx = obs_new[0] - obs_old[0];
+        let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
+        Some([dy / norm, dx / norm])
+    }
+
+    /// Last observed centre `(cx, cy)`; used by the OCM bonus and round-2 re-match.
+    pub(super) fn last_observation(&self) -> &MeasurementVector {
+        &self
+            .observations
+            .last()
+            .expect("observations is non-empty by invariant")
+            .0
+    }
+
+    /// ORU: replay interpolated observations to correct KF drift after re-association.
+    pub(super) fn our_re_update(
+        &mut self,
+        current_xyah: &MeasurementVector,
+        current_frame: usize,
+        kf: &KalmanFilter,
+    ) {
+        let n = self.observations.len();
+        if n == 0 {
+            return;
+        }
+        let (last_obs, last_frame) = &self.observations[n - 1];
+        let gap = (current_frame as isize - *last_frame as isize).max(1) as usize;
+        if gap <= 1 {
+            return;
+        }
+
+        let last_tlwh = xyah_to_tlwh(last_obs);
+        let current_tlwh = xyah_to_tlwh(current_xyah);
+        let (mut mean, mut covariance) = kf.initiate(last_obs);
+
+        for step in 1..=gap {
+            let t = step as f32 / gap as f32;
+            let virtual_tlwh = [
+                last_tlwh[0] + (current_tlwh[0] - last_tlwh[0]) * t,
+                last_tlwh[1] + (current_tlwh[1] - last_tlwh[1]) * t,
+                last_tlwh[2] + (current_tlwh[2] - last_tlwh[2]) * t,
+                last_tlwh[3] + (current_tlwh[3] - last_tlwh[3]) * t,
+            ];
+            let virtual_xyah = tlwh_to_xyah(&virtual_tlwh);
+            let (pm, pc) = kf.predict(&mean, &covariance);
+            mean = pm;
+            covariance = pc;
+            let (um, uc) = kf.update(&mean, &covariance, &virtual_xyah);
+            mean = um;
+            covariance = uc;
+        }
+
+        self.kalman.mean = mean;
+        self.kalman.covariance = covariance;
+        self.tlwh = xyah_to_tlwh(&self.kalman.mean);
+    }
+
+    /// Record a new observation, keeping the history bounded to `max_obs` entries.
+    pub(super) fn push_observation(
+        &mut self,
+        xyah: MeasurementVector,
+        frame_id: usize,
+        max_obs: usize,
+    ) {
+        self.observations.push((xyah, frame_id));
+        if self.observations.len() > max_obs {
+            self.observations.remove(0);
+        }
+    }
+
+    /// Buffer an appearance embedding to be flushed into the gallery this frame.
+    pub(super) fn push_feature(&mut self, feature: Vec<f32>) {
+        self.pending_features.push(feature);
+    }
+
+    /// Drain the buffered embeddings collected since the last flush.
+    pub(super) fn take_features(&mut self) -> Vec<Vec<f32>> {
+        std::mem::take(&mut self.pending_features)
+    }
+
+    pub(super) fn mark_deleted(&mut self) {
+        self.state = TrackState::Deleted;
+    }
+
+    pub(super) fn is_confirmed(&self) -> bool {
+        self.state == TrackState::Confirmed
+    }
+}

--- a/src/trackers/deep_ocsort/track.rs
+++ b/src/trackers/deep_ocsort/track.rs
@@ -117,11 +117,10 @@ impl DeepOcSortTrack {
         current_frame: usize,
         kf: &KalmanFilter,
     ) {
-        let n = self.observations.len();
-        if n == 0 {
-            return;
-        }
-        let (last_obs, last_frame) = &self.observations[n - 1];
+        let (last_obs, last_frame) = self
+            .observations
+            .last()
+            .expect("observations is non-empty by invariant");
         let gap = (current_frame as isize - *last_frame as isize).max(1) as usize;
         if gap <= 1 {
             return;
@@ -182,5 +181,61 @@ impl DeepOcSortTrack {
 
     pub(super) fn is_confirmed(&self) -> bool {
         self.state == TrackState::Confirmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_track() -> DeepOcSortTrack {
+        let kf = KalmanFilter::default();
+        DeepOcSortTrack::new(
+            [100.0, 100.0, 50.0, 100.0],
+            0.9,
+            0,
+            1,
+            1,
+            Some(vec![1.0, 0.0]),
+            &kf,
+        )
+    }
+
+    #[test]
+    fn obs_direction_needs_two_observations() {
+        let mut track = make_track();
+        assert!(track.obs_direction(3).is_none());
+        track.push_observation(tlwh_to_xyah(&[110.0, 100.0, 50.0, 100.0]), 2, 4);
+        let dir = track.obs_direction(3).unwrap();
+        assert!(dir[0].abs() < 0.01 && (dir[1] - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn push_observation_is_bounded() {
+        let mut track = make_track();
+        for frame in 2..12 {
+            track.push_observation(tlwh_to_xyah(&[100.0, 100.0, 50.0, 100.0]), frame, 4);
+        }
+        // History stays bounded, so a direction is still computable without panic.
+        assert!(track.obs_direction(3).is_some());
+    }
+
+    #[test]
+    fn our_re_update_stays_finite_after_gap() {
+        let kf = KalmanFilter::default();
+        let mut track = make_track();
+        for _ in 0..5 {
+            track.predict(&kf);
+        }
+        track.our_re_update(&tlwh_to_xyah(&[130.0, 100.0, 50.0, 100.0]), 7, &kf);
+        assert!(track.tlwh.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn take_features_drains_buffer() {
+        let mut track = make_track();
+        track.push_feature(vec![0.5, 0.5]);
+        assert_eq!(track.take_features().len(), 2);
+        assert!(track.take_features().is_empty());
     }
 }

--- a/src/trackers/deep_ocsort/track.rs
+++ b/src/trackers/deep_ocsort/track.rs
@@ -1,6 +1,6 @@
 //! Per-track state for Deep OC-SORT: OC-SORT motion plus an appearance buffer.
 
-use crate::trackers::common::{KalmanTrack, TrackState};
+use crate::trackers::common::{CameraMotion, KalmanTrack, TrackState};
 use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
 use crate::utils::kalman::{KalmanFilter, MeasurementVector};
 
@@ -82,6 +82,14 @@ impl DeepOcSortTrack {
     pub(super) fn update_kf(&mut self, xyah: &MeasurementVector, kf: &KalmanFilter) {
         self.kalman.update(xyah, kf);
         self.tlwh = xyah_to_tlwh(&self.kalman.mean);
+    }
+
+    /// Warp the predicted state and observation history by a camera motion transform.
+    pub(super) fn apply_camera_motion(&mut self, cmc: &CameraMotion) {
+        self.tlwh = self.kalman.apply_camera_motion(cmc);
+        for (obs, _) in &mut self.observations {
+            cmc.apply_observation(obs);
+        }
     }
 
     /// OCV: normalised `[dy, dx]` velocity direction over the last `delta_t` frames.

--- a/src/trackers/deep_ocsort/tracker.rs
+++ b/src/trackers/deep_ocsort/tracker.rs
@@ -1,6 +1,7 @@
 //! Deep OC-SORT association: OC-SORT motion plus an appearance affinity term.
 
 use super::track::DeepOcSortTrack;
+use crate::trackers::common::CameraMotion;
 use crate::trackers::deepsort::NearestNeighborDistanceMetric;
 use crate::utils::assignment::greedy_match;
 use crate::utils::geometry::{iou_batch, tlwh_to_xyah, xyah_to_tlwh};
@@ -73,6 +74,19 @@ impl DeepOcSortTracker {
         detections: &[([f32; 4], f32, i64)],
         embeddings: &[Vec<f32>],
     ) -> Vec<DeepOcSortTrack> {
+        self.update_with_camera_motion(detections, embeddings, &CameraMotion::identity())
+    }
+
+    /// Update the tracker, first warping track predictions by `camera_motion`.
+    ///
+    /// `camera_motion` maps the previous frame's coordinates into the current frame
+    /// (see [`CameraMotion`]); pass [`CameraMotion::identity`] for a static camera.
+    pub fn update_with_camera_motion(
+        &mut self,
+        detections: &[([f32; 4], f32, i64)],
+        embeddings: &[Vec<f32>],
+        camera_motion: &CameraMotion,
+    ) -> Vec<DeepOcSortTrack> {
         self.frame_count += 1;
 
         let use_appearance = !embeddings.is_empty() && embeddings.len() == detections.len();
@@ -85,8 +99,12 @@ impl DeepOcSortTracker {
             })
             .collect();
 
+        let warp = !camera_motion.is_identity();
         for track in &mut self.tracks {
             track.predict(&self.kf);
+            if warp {
+                track.apply_camera_motion(camera_motion);
+            }
         }
 
         let (matches, unmatched_dets, unmatched_trks) =

--- a/src/trackers/deep_ocsort/tracker.rs
+++ b/src/trackers/deep_ocsort/tracker.rs
@@ -1,0 +1,293 @@
+//! Deep OC-SORT association: OC-SORT motion plus an appearance affinity term.
+
+use super::track::DeepOcSortTrack;
+use crate::trackers::deepsort::NearestNeighborDistanceMetric;
+use crate::utils::assignment::greedy_match;
+use crate::utils::geometry::{iou_batch, tlwh_to_xyah, xyah_to_tlwh};
+use crate::utils::kalman::KalmanFilter;
+use std::collections::HashSet;
+
+/// A detection paired with its optional appearance embedding.
+struct Detection {
+    tlwh: [f32; 4],
+    score: f32,
+    class_id: i64,
+}
+
+/// Deep OC-SORT tracker core.
+///
+/// Runs the OC-SORT motion association (IoU with an OCM direction bonus, plus an
+/// ORU re-update on re-association) and blends in an appearance cost from a cosine
+/// feature gallery. The appearance weight scales with detector confidence (dynamic
+/// appearance) and is gated by `max_cosine_distance`. With `appearance_weight = 0`
+/// the association reduces to plain OC-SORT.
+pub struct DeepOcSortTracker {
+    pub tracks: Vec<DeepOcSortTrack>,
+    max_age: usize,
+    min_hits: usize,
+    iou_threshold: f32,
+    delta_t: usize,
+    inertia: f32,
+    appearance_weight: f32,
+    max_cosine_distance: f32,
+    metric: NearestNeighborDistanceMetric,
+    kf: KalmanFilter,
+    next_id: u64,
+    frame_count: usize,
+}
+
+impl DeepOcSortTracker {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        max_age: usize,
+        min_hits: usize,
+        iou_threshold: f32,
+        delta_t: usize,
+        inertia: f32,
+        appearance_weight: f32,
+        max_cosine_distance: f32,
+        metric: NearestNeighborDistanceMetric,
+    ) -> Self {
+        Self {
+            tracks: Vec::new(),
+            max_age,
+            min_hits,
+            iou_threshold,
+            delta_t,
+            inertia: inertia.clamp(0.0, 1.0),
+            appearance_weight: appearance_weight.clamp(0.0, 1.0),
+            max_cosine_distance,
+            metric,
+            kf: KalmanFilter::default(),
+            next_id: 1,
+            frame_count: 0,
+        }
+    }
+
+    /// Update the tracker with the current frame's detections and embeddings.
+    ///
+    /// `embeddings` is parallel to `detections`. Pass an empty slice to run without
+    /// appearance (pure OC-SORT). Returns confirmed tracks matched this frame.
+    pub fn update(
+        &mut self,
+        detections: &[([f32; 4], f32, i64)],
+        embeddings: &[Vec<f32>],
+    ) -> Vec<DeepOcSortTrack> {
+        self.frame_count += 1;
+
+        let use_appearance = !embeddings.is_empty() && embeddings.len() == detections.len();
+        let dets: Vec<Detection> = detections
+            .iter()
+            .map(|(tlwh, score, class_id)| Detection {
+                tlwh: *tlwh,
+                score: *score,
+                class_id: *class_id,
+            })
+            .collect();
+
+        for track in &mut self.tracks {
+            track.predict(&self.kf);
+        }
+
+        let (matches, unmatched_dets, unmatched_trks) =
+            self.associate(&dets, embeddings, use_appearance);
+
+        for (det_idx, trk_idx) in &matches {
+            let det = &dets[*det_idx];
+            let xyah = tlwh_to_xyah(&det.tlwh);
+            let track = &mut self.tracks[*trk_idx];
+
+            if track.time_since_update > 0 {
+                track.our_re_update(&xyah, self.frame_count, &self.kf);
+            }
+            track.update_kf(&xyah, &self.kf);
+            track.push_observation(xyah, self.frame_count, self.delta_t + 1);
+
+            track.tlwh = det.tlwh;
+            track.score = det.score;
+            track.class_id = det.class_id;
+            track.hits += 1;
+            track.hit_streak += 1;
+            track.time_since_update = 0;
+
+            if use_appearance {
+                track.push_feature(embeddings[*det_idx].clone());
+            }
+        }
+
+        for det_idx in unmatched_dets {
+            let det = &dets[det_idx];
+            let feature = use_appearance.then(|| embeddings[det_idx].clone());
+            let track = DeepOcSortTrack::new(
+                det.tlwh,
+                det.score,
+                det.class_id,
+                self.next_id,
+                self.frame_count,
+                feature,
+                &self.kf,
+            );
+            self.next_id += 1;
+            self.tracks.push(track);
+        }
+
+        for track in &mut self.tracks {
+            if track.time_since_update == 0 && track.hit_streak >= self.min_hits {
+                track.state = crate::trackers::common::TrackState::Confirmed;
+            }
+            if track.time_since_update > self.max_age {
+                track.mark_deleted();
+            }
+        }
+
+        let unmatched_set: HashSet<usize> = unmatched_trks.into_iter().collect();
+        for (i, track) in self.tracks.iter_mut().enumerate() {
+            if unmatched_set.contains(&i)
+                && track.state == crate::trackers::common::TrackState::Tentative
+            {
+                track.mark_deleted();
+            }
+        }
+
+        self.tracks
+            .retain(|t| t.state != crate::trackers::common::TrackState::Deleted);
+
+        self.flush_gallery();
+
+        self.tracks
+            .iter()
+            .filter(|t| t.is_confirmed() && t.time_since_update == 0)
+            .cloned()
+            .collect()
+    }
+
+    /// Push each track's buffered embeddings into the gallery and drop galleries
+    /// for tracks that no longer exist.
+    fn flush_gallery(&mut self) {
+        let active: Vec<u64> = self.tracks.iter().map(|t| t.track_id).collect();
+        let mut features: Vec<(u64, Vec<f32>)> = Vec::new();
+        for track in &mut self.tracks {
+            let id = track.track_id;
+            for feature in track.take_features() {
+                features.push((id, feature));
+            }
+        }
+        if !features.is_empty() || !active.is_empty() {
+            self.metric.partial_fit(&features, &active);
+        }
+    }
+
+    /// Two-round association: motion (IoU + OCM) blended with appearance in round 1,
+    /// then a motion-only round 2 on last observed positions.
+    ///
+    /// Returns matches as `(detection, track)` pairs plus the unmatched detections
+    /// and tracks.
+    fn associate(
+        &self,
+        detections: &[Detection],
+        embeddings: &[Vec<f32>],
+        use_appearance: bool,
+    ) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
+        let n_trks = self.tracks.len();
+        let n_dets = detections.len();
+
+        if n_trks == 0 {
+            return (Vec::new(), (0..n_dets).collect(), Vec::new());
+        }
+        if n_dets == 0 {
+            return (Vec::new(), Vec::new(), (0..n_trks).collect());
+        }
+
+        let pred_boxes: Vec<[f32; 4]> = self.tracks.iter().map(|t| t.tlwh).collect();
+        let det_boxes: Vec<[f32; 4]> = detections.iter().map(|d| d.tlwh).collect();
+        let ious = iou_batch(&pred_boxes, &det_boxes);
+
+        // OCM direction-consistency bonus, identical to OC-SORT.
+        let mut angle_diff: Vec<Vec<f32>> = vec![vec![0.0_f32; n_dets]; n_trks];
+        for (i, track) in self.tracks.iter().enumerate() {
+            let vel_dir = match track.obs_direction(self.delta_t) {
+                Some(v) => v,
+                None => continue,
+            };
+            let last = track.last_observation();
+            let (last_cx, last_cy) = (last[0], last[1]);
+            for (j, det) in detections.iter().enumerate() {
+                let det_cx = det.tlwh[0] + det.tlwh[2] / 2.0;
+                let det_cy = det.tlwh[1] + det.tlwh[3] / 2.0;
+                let dy = det_cy - last_cy;
+                let dx = det_cx - last_cx;
+                let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
+                let dot = (vel_dir[0] * (dy / norm) + vel_dir[1] * (dx / norm)).clamp(-1.0, 1.0);
+                let angle = dot.acos();
+                let normalized = (std::f32::consts::FRAC_PI_2 - angle.abs()) / std::f32::consts::PI;
+                angle_diff[i][j] = (normalized * self.inertia * det.score).max(0.0);
+            }
+        }
+
+        // Appearance cost matrix (n_trks x n_dets) of cosine distances, or empty.
+        let app_cost = if use_appearance {
+            let track_ids: Vec<u64> = self.tracks.iter().map(|t| t.track_id).collect();
+            self.metric.distance(embeddings, &track_ids)
+        } else {
+            Vec::new()
+        };
+
+        let cost_matrix: Vec<Vec<f32>> = (0..n_trks)
+            .map(|i| {
+                (0..n_dets)
+                    .map(|j| {
+                        let motion_cost = 1.0 - (ious[i][j] + angle_diff[i][j]);
+                        if use_appearance {
+                            let app = app_cost[i][j];
+                            if app <= self.max_cosine_distance {
+                                let eff_w = self.appearance_weight * detections[j].score;
+                                return (1.0 - eff_w) * motion_cost + eff_w * (app / 2.0);
+                            }
+                        }
+                        motion_cost
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let (matches_td, mut unmatched_trks, mut unmatched_dets) =
+            greedy_match(&cost_matrix, 1.0 - self.iou_threshold);
+        let mut matches: Vec<(usize, usize)> = matches_td
+            .into_iter()
+            .map(|(trk, det)| (det, trk))
+            .collect();
+
+        // Round 2: motion-only re-match on last observed positions.
+        if !unmatched_dets.is_empty() && !unmatched_trks.is_empty() {
+            let left_det_boxes: Vec<[f32; 4]> = unmatched_dets
+                .iter()
+                .map(|&di| detections[di].tlwh)
+                .collect();
+            let left_trk_obs: Vec<[f32; 4]> = unmatched_trks
+                .iter()
+                .map(|&ti| xyah_to_tlwh(self.tracks[ti].last_observation()))
+                .collect();
+            let iou_left = iou_batch(&left_trk_obs, &left_det_boxes);
+            let max_iou = iou_left
+                .iter()
+                .flat_map(|r| r.iter())
+                .cloned()
+                .fold(f32::NEG_INFINITY, f32::max);
+
+            if max_iou > self.iou_threshold {
+                let cost_left: Vec<Vec<f32>> = iou_left
+                    .iter()
+                    .map(|row| row.iter().map(|&v| 1.0 - v).collect())
+                    .collect();
+                let (r2_matches, r2_ut, r2_ud) = greedy_match(&cost_left, 1.0 - self.iou_threshold);
+                for (trk_local, det_local) in r2_matches {
+                    matches.push((unmatched_dets[det_local], unmatched_trks[trk_local]));
+                }
+                unmatched_dets = r2_ud.into_iter().map(|di| unmatched_dets[di]).collect();
+                unmatched_trks = r2_ut.into_iter().map(|ti| unmatched_trks[ti]).collect();
+            }
+        }
+
+        (matches, unmatched_dets, unmatched_trks)
+    }
+}

--- a/src/trackers/deepsort/mod.rs
+++ b/src/trackers/deepsort/mod.rs
@@ -9,14 +9,13 @@ mod tracker;
 #[cfg(feature = "python")]
 pub mod python;
 
-pub use nn_matching::Metric;
+pub use nn_matching::{Metric, NearestNeighborDistanceMetric};
 pub use track::{Track, TrackState};
 pub use tracker::DeepSortTracker;
 
 use crate::traits::AppearanceExtractor;
 use crate::types::BoundingBox;
 use image::DynamicImage;
-use nn_matching::NearestNeighborDistanceMetric;
 use std::error::Error;
 
 /// Build the inner DeepSORT tracker shared by the Rust and Python constructors.

--- a/src/trackers/mod.rs
+++ b/src/trackers/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod byte_track;
 pub mod common;
+pub mod deep_ocsort;
 pub mod deepsort;
 pub mod ocsort;
 pub mod sort;

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -151,3 +151,53 @@ def test_sort_update_confirmed_after_min_hits():
         t.update(det)
     tracks = t.update(det)
     assert len(tracks) == 1
+
+
+# ---------------------------------------------------------------------------
+# DEEPOCSORT
+# ---------------------------------------------------------------------------
+
+
+def test_deepocsort_constructor():
+    t = trackforge.DEEPOCSORT(
+        max_age=30,
+        min_hits=1,
+        iou_threshold=0.3,
+        delta_t=3,
+        inertia=0.2,
+        appearance_weight=0.5,
+        max_cosine_distance=0.2,
+        nn_budget=100,
+    )
+    assert t is not None
+
+
+def test_deepocsort_update_empty():
+    t = trackforge.DEEPOCSORT(min_hits=1)
+    assert t.update([]) == []
+
+
+def test_deepocsort_motion_only():
+    # No embeddings: tracks on motion alone (pure OC-SORT behaviour).
+    t = trackforge.DEEPOCSORT(min_hits=1)
+    tracks = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
+    assert len(tracks) == 1
+    track_id, tlwh, score, class_id = tracks[0]
+    assert track_id == 1
+    assert len(tlwh) == 4
+
+
+def test_deepocsort_with_embeddings_keeps_id():
+    t = trackforge.DEEPOCSORT(min_hits=1, max_cosine_distance=0.3)
+    emb = [[1.0, 0.0, 0.0]]
+    first = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)], emb)
+    track_id = first[0][0]
+    second = t.update([([104.0, 100.0, 50.0, 100.0], 0.9, 0)], emb)
+    assert len(second) == 1
+    assert second[0][0] == track_id
+
+
+def test_deepocsort_mismatched_embeddings_raises():
+    t = trackforge.DEEPOCSORT(min_hits=1)
+    with pytest.raises(ValueError):
+        t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)], [[1.0], [2.0]])

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -201,3 +201,15 @@ def test_deepocsort_mismatched_embeddings_raises():
     t = trackforge.DEEPOCSORT(min_hits=1)
     with pytest.raises(ValueError):
         t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)], [[1.0], [2.0]])
+
+
+def test_deepocsort_camera_motion_keeps_id():
+    t = trackforge.DEEPOCSORT(min_hits=1)
+    first = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
+    track_id = first[0][0]
+    # Camera pans right by 200px; the object now appears at x=300. The affine
+    # [a, b, tx, c, d, ty] warps the prediction so the track is kept.
+    camera_motion = [1.0, 0.0, 200.0, 0.0, 1.0, 0.0]
+    second = t.update([([300.0, 100.0, 50.0, 100.0], 0.9, 0)], [], camera_motion)
+    assert len(second) == 1
+    assert second[0][0] == track_id


### PR DESCRIPTION
Adds a Deep OC-SORT tracker under src/trackers/deep_ocsort. It runs the OC-SORT motion association (OCM direction bonus and ORU re-update) and blends in an appearance term: a cosine distance to a per-track feature gallery, scaled by detector confidence and gated by max_cosine_distance. Setting appearance_weight to 0 reduces it to OC-SORT.

It also adds camera motion compensation as shared common::cmc infrastructure. A CameraMotion affine transform (supplied by the caller, for example from image registration) warps track predictions before association. The same module is meant to be reused by future trackers like BoT-SORT and StrongSORT++. The core stays free of vision dependencies since it does not estimate the transform itself.

It reuses common::KalmanTrack, the geometry and assignment helpers, and DeepSORT's NearestNeighborDistanceMetric. The Rust API is a DeepOcSort wrapper over an AppearanceExtractor (with update and update_with_camera_motion), and the DEEPOCSORT Python class takes detections with optional embeddings and an optional camera_motion affine. README, book, roadmap, crate docs, and the type stub are updated.