### PR TITLE
refactor(examples): unify python demos on shared helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     <a href="https://crates.io/crates/trackforge"><img src="https://img.shields.io/crates/msrv/trackforge?logo=rust&logoColor=white" alt="MSRV" /></a>
     <a href="https://pypi.org/project/trackforge/"><img src="https://img.shields.io/pypi/v/trackforge?logo=python&logoColor=white&label=PyPI" alt="PyPI version" /></a>
     <a href="https://pypi.org/project/trackforge/#downloads"><img src="https://img.shields.io/pypi/dm/trackforge?logo=python&logoColor=white&label=pip%20downloads" alt="PyPI downloads" /></a>
+    <a href="https://pypi.org/project/trackforge/"><img src="https://img.shields.io/pypi/pyversions/trackforge?logo=python&logoColor=white&label=python" alt="Python versions" /></a>
     <a href="https://github.com/onuralpszr/trackforge/actions/workflows/CI.yml"><img src="https://img.shields.io/github/actions/workflow/status/onuralpszr/trackforge/CI.yml?branch=main&logo=githubactions&logoColor=white&label=CI" alt="CI" /></a>
     <a href="https://codecov.io/gh/onuralpszr/trackforge"><img src="https://img.shields.io/codecov/c/github/onuralpszr/trackforge?logo=codecov&logoColor=white&token=DHMFYRLJW1" alt="Coverage" /></a>
     <a href="https://deps.rs/repo/github/onuralpszr/trackforge"><img src="https://deps.rs/repo/github/onuralpszr/trackforge/status.svg" alt="dependency status" /></a>
@@ -252,13 +253,14 @@ for t in tracks {
 
 Runnable demos live under [`examples/`](examples/), with both a Python and a Rust entry per tracker.
 
-| Tracker   | Python                                                                                                                                  | Rust                                                                                                      |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| ByteTrack | [`byte_track_demo.py`](examples/python/byte_track_demo.py) (YOLO11)                                                                     | [`byte_track_demo.rs`](examples/rust/byte_track_demo.rs)                                                  |
-| DeepSORT  | [`deepsort_demo.py`](examples/python/deepsort_demo.py) (YOLO + ResNet18)                                                                | [`deepsort_simple.rs`](examples/deepsort_simple.rs), [`deepsort_ort.rs`](examples/deepsort_ort.rs) (ONNX) |
-| OC-SORT   | [`ocsort_demo.py`](examples/python/ocsort_demo.py)                                                                                      | —                                                                                                         |
-| SORT      | [`sort_yolo_demo.py`](examples/python/sort_yolo_demo.py) (YOLO), [`sort_rtdetr_demo.py`](examples/python/sort_rtdetr_demo.py) (RT-DETR) | —                                                                                                         |
-| All four  | [`tracker_comparison.py`](examples/python/tracker_comparison.py) (side-by-side benchmark)                                               | —                                                                                                         |
+| Tracker      | Python                                                                                                                                  | Rust                                                                                                      |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| ByteTrack    | [`byte_track_demo.py`](examples/python/byte_track_demo.py) (YOLO11)                                                                     | [`byte_track_demo.rs`](examples/rust/byte_track_demo.rs)                                                  |
+| DeepSORT     | [`deepsort_demo.py`](examples/python/deepsort_demo.py) (YOLO + ResNet18)                                                                | [`deepsort_simple.rs`](examples/deepsort_simple.rs), [`deepsort_ort.rs`](examples/deepsort_ort.rs) (ONNX) |
+| OC-SORT      | [`ocsort_demo.py`](examples/python/ocsort_demo.py)                                                                                      | —                                                                                                         |
+| Deep OC-SORT | [`deep_ocsort_demo.py`](examples/python/deep_ocsort_demo.py) (YOLO + ResNet18)                                                          | —                                                                                                         |
+| SORT         | [`sort_yolo_demo.py`](examples/python/sort_yolo_demo.py) (YOLO), [`sort_rtdetr_demo.py`](examples/python/sort_rtdetr_demo.py) (RT-DETR) | —                                                                                                         |
+| Comparison   | [`tracker_comparison.py`](examples/python/tracker_comparison.py) (ByteTrack vs SORT side-by-side)                                       | —                                                                                                         |
 
 ```bash
 # Python

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,98 +1,86 @@
 # Python Examples
 
-This directory contains Python examples demonstrating trackforge's tracking capabilities with various object detection models.
+Runnable demos for every trackforge tracker. Each demo reads a video, runs a detector, feeds detections to a tracker, and writes an annotated video. They share the same command-line interface and the same drawing/plumbing helpers.
 
 ## Prerequisites
 
 ```bash
-# Install trackforge
+# Core
 pip install trackforge
 
-# For YOLO examples
+# YOLO demos (SORT, ByteTrack, OC-SORT, Deep SORT, Deep OC-SORT, comparison)
 pip install ultralytics opencv-python
 
-# For RT-DETR examples
-pip install transformers torch pillow opencv-python
+# RT-DETR demo
+pip install transformers torch pillow
 
-# For Deep SORT examples (appearance embeddings)
-pip install torch torchvision
+# Appearance demos (Deep SORT, Deep OC-SORT) need a Re-ID backbone
+pip install torch torchvision pillow
 ```
 
 ## Examples
 
-| Example                                          | Description                        | Tracker     | Detector               | Input            | Output                   |
-| ------------------------------------------------ | ---------------------------------- | ----------- | ---------------------- | ---------------- | ------------------------ |
-| [`byte_track_demo.py`](byte_track_demo.py)       | ByteTrack multi-object tracking    | `ByteTrack` | YOLO11n                | `test_video.mp4` | `output_tracking.mp4`    |
-| [`sort_yolo_demo.py`](sort_yolo_demo.py)         | SORT tracking with YOLO            | `Sort`      | YOLO11n                | `people.mp4`     | `output_sort_yolo.mp4`   |
-| [`sort_rtdetr_demo.py`](sort_rtdetr_demo.py)     | SORT tracking with RT-DETR         | `Sort`      | RT-DETR (Transformers) | `people.mp4`     | `output_sort_rtdetr.mp4` |
-| [`deepsort_demo.py`](deepsort_demo.py)           | Deep SORT with appearance features | `DeepSort`  | YOLO11n + ResNet18     | `people.mp4`     | `output_deepsort.mp4`    |
-| [`tracker_comparison.py`](tracker_comparison.py) | Side-by-side ByteTrack vs SORT     | Both        | YOLO11n                | `people.mp4`     | `output_comparison.mp4`  |
+| Example                                          | Tracker              | Detector           | Output                   |
+| ------------------------------------------------ | -------------------- | ------------------ | ------------------------ |
+| [`sort_yolo_demo.py`](sort_yolo_demo.py)         | `SORT`               | YOLO11n            | `output_sort_yolo.mp4`   |
+| [`sort_rtdetr_demo.py`](sort_rtdetr_demo.py)     | `SORT`               | RT-DETR            | `output_sort_rtdetr.mp4` |
+| [`byte_track_demo.py`](byte_track_demo.py)       | `BYTETRACK`          | YOLO11n            | `output_bytetrack.mp4`   |
+| [`ocsort_demo.py`](ocsort_demo.py)               | `OCSORT`             | YOLO11n            | `output_ocsort.mp4`      |
+| [`deepsort_demo.py`](deepsort_demo.py)           | `DEEPSORT`           | YOLO11n + ResNet18 | `output_deepsort.mp4`    |
+| [`deep_ocsort_demo.py`](deep_ocsort_demo.py)     | `DEEPOCSORT`         | YOLO11n + ResNet18 | `output_deep_ocsort.mp4` |
+| [`tracker_comparison.py`](tracker_comparison.py) | `BYTETRACK` + `SORT` | YOLO11n            | `output_comparison.mp4`  |
+
+Two shared modules back the demos (not runnable on their own):
+
+- [`common.py`](common.py) - video load, MP4 writer, YOLO-to-`tlwh` conversion, color palette, box/label drawing, progress logging.
+- [`reid.py`](reid.py) - ResNet18 appearance embedder shared by the Deep SORT and Deep OC-SORT demos.
+
+## Running
+
+Every demo takes the same options and defaults to `people.mp4`:
+
+```bash
+python sort_yolo_demo.py --video people.mp4 --output tracked.mp4 --model yolo11n.pt
+```
+
+`deep_ocsort_demo.py` also accepts `--no-reid` to track on motion alone (pure OC-SORT behavior). `sort_rtdetr_demo.py` takes a Hugging Face model id via `--model` (default `PekingU/rtdetr_r50vd`).
 
 ## Quick Start
 
-### ByteTrack with YOLO
-
 ```python
 import trackforge
 from ultralytics import YOLO
 
 model = YOLO("yolo11n.pt")
-tracker = trackforge.ByteTrack(track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6)
+tracker = trackforge.SORT(max_age=30, min_hits=3, iou_threshold=0.3)
 
-# Process detections
-results = model.predict(frame, verbose=False)
-detections = [(box.tlwh, box.conf, box.cls) for box in results[0].boxes]
+results = model.predict(frame, verbose=False, classes=[0])
+detections = []
+for box in results[0].boxes:
+    x1, y1, x2, y2 = box.xyxy[0].cpu().numpy()
+    detections.append(([float(x1), float(y1), float(x2 - x1), float(y2 - y1)],
+                       float(box.conf[0]), int(box.cls[0])))
+
 tracks = tracker.update(detections)
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID {track_id}: {tlwh}")
 ```
 
-### SORT with YOLO
+Swap the tracker line for any of the others:
 
 ```python
-import trackforge
-from ultralytics import YOLO
-
-model = YOLO("yolo11n.pt")
-tracker = trackforge.Sort(max_age=30, min_hits=3, iou_threshold=0.3)
-
-# Process detections
-results = model.predict(frame, verbose=False)
-detections = [(box.tlwh, box.conf, box.cls) for box in results[0].boxes]
-tracks = tracker.update(detections)
+trackforge.BYTETRACK(track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6)
+trackforge.OCSORT(max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2)
+trackforge.DEEPSORT(max_age=70, n_init=3, max_iou_distance=0.7, max_cosine_distance=0.2, nn_budget=100)
+trackforge.DEEPOCSORT(max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2,
+                      appearance_weight=0.5, max_cosine_distance=0.2, nn_budget=100)
 ```
 
-### Deep SORT with Appearance Embeddings
-
-```python
-import trackforge
-from ultralytics import YOLO
-
-model = YOLO("yolo11n.pt")
-tracker = trackforge.DeepSort(
-    max_age=70,
-    n_init=3,
-    max_iou_distance=0.7,
-    max_cosine_distance=0.2,
-    nn_budget=100
-)
-
-# Process detections
-results = model.predict(frame, verbose=False)
-detections = [(box.tlwh, box.conf, box.cls) for box in results[0].boxes]
-
-# Extract appearance embeddings (e.g., using ResNet18)
-embeddings = extract_features(frame, detections)  # Your feature extractor
-
-# Update tracker with detections AND embeddings
-tracks = tracker.update(detections, embeddings)
-
-# Access track attributes
-for track in tracks:
-    print(f"ID: {track.track_id}, Box: {track.tlwh}")
-```
+`DEEPSORT` and `DEEPOCSORT` take a parallel list of appearance embeddings: `tracker.update(detections, embeddings)`. For `DEEPOCSORT` the embeddings are optional (omit them to track on motion only).
 
 ## API Reference
 
-### ByteTrack
+### BYTETRACK
 
 | Parameter      | Type  | Default | Description                            |
 | -------------- | ----- | ------- | -------------------------------------- |
@@ -101,7 +89,7 @@ for track in tracks:
 | `match_thresh` | float | 0.8     | IoU threshold for matching             |
 | `det_thresh`   | float | 0.6     | Threshold for new track initialization |
 
-### Sort
+### SORT
 
 | Parameter       | Type  | Default | Description                                  |
 | --------------- | ----- | ------- | -------------------------------------------- |
@@ -109,7 +97,17 @@ for track in tracks:
 | `min_hits`      | int   | 3       | Min consecutive hits to confirm track        |
 | `iou_threshold` | float | 0.3     | IoU threshold for matching                   |
 
-### DeepSort
+### OCSORT
+
+| Parameter       | Type  | Default | Description                                  |
+| --------------- | ----- | ------- | -------------------------------------------- |
+| `max_age`       | int   | 30      | Max frames without detection before deletion |
+| `min_hits`      | int   | 3       | Min consecutive hits to confirm track        |
+| `iou_threshold` | float | 0.3     | IoU threshold for matching                   |
+| `delta_t`       | int   | 3       | Frame window for velocity direction (OCM)    |
+| `inertia`       | float | 0.2     | Weight of the velocity-direction bonus       |
+
+### DEEPSORT
 
 | Parameter             | Type  | Default | Description                                  |
 | --------------------- | ----- | ------- | -------------------------------------------- |
@@ -119,28 +117,28 @@ for track in tracks:
 | `max_cosine_distance` | float | 0.2     | Max cosine distance for appearance matching  |
 | `nn_budget`           | int   | 100     | Max appearance features stored per track     |
 
+### DEEPOCSORT
+
+| Parameter             | Type  | Default | Description                                    |
+| --------------------- | ----- | ------- | ---------------------------------------------- |
+| `max_age`             | int   | 30      | Max frames without detection before deletion   |
+| `min_hits`            | int   | 3       | Min consecutive hits to confirm track          |
+| `iou_threshold`       | float | 0.3     | IoU threshold for matching                     |
+| `delta_t`             | int   | 3       | Frame window for velocity direction (OCM)      |
+| `inertia`             | float | 0.2     | Weight of the velocity-direction bonus         |
+| `appearance_weight`   | float | 0.5     | Blend weight for the appearance cost (0 = off) |
+| `max_cosine_distance` | float | 0.2     | Gate above which appearance is ignored         |
+| `nn_budget`           | int   | 100     | Max appearance features stored per track       |
+
 ## Output Format
 
-### ByteTrack / Sort
-
-Both trackers return a list of tracks as tuples:
+Every tracker returns a list of tuples:
 
 ```python
 (track_id, [x, y, w, h], score, class_id)
 ```
 
-- `track_id`: Unique integer identifier for the track
-- `[x, y, w, h]`: Bounding box in TLWH format (top-left x, y, width, height)
-- `score`: Detection confidence score
-- `class_id`: Object class ID from the detector
-
-### DeepSort
-
-Returns a list of `DeepSortTrack` objects with attributes:
-
-```python
-track.track_id  # Unique integer identifier
-track.tlwh      # Bounding box [x, y, w, h]
-track.score     # Detection confidence
-track.class_id  # Object class ID
-```
+- `track_id`: unique integer identifier for the track
+- `[x, y, w, h]`: bounding box in TLWH format (top-left x, y, width, height)
+- `score`: detection confidence
+- `class_id`: object class id from the detector

--- a/examples/python/byte_track_demo.py
+++ b/examples/python/byte_track_demo.py
@@ -1,117 +1,95 @@
-import cv2
-from ultralytics import YOLO
-import trackforge
+#!/usr/bin/env python3
+"""ByteTrack tracking demo with an Ultralytics YOLO detector.
+
+Requirements:
+    pip install ultralytics opencv-python trackforge
+
+Example:
+    $ python byte_track_demo.py --video people.mp4 --model yolo11n.pt
+"""
+
+from __future__ import annotations
+
+import argparse
 import time
+from pathlib import Path
+
+from ultralytics import YOLO
+
+import trackforge
+from common import (
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    label_for,
+    load_video,
+    log_progress,
+    yolo_detections,
+)
 
 
-def run_tracking(video_path="test_video.mp4", output_path="output_tracking.mp4"):
-    # Load model
-    model = YOLO("yolo11n.pt")
+def run_tracking(video: str, output: str, model_path: str) -> None:
+    """Run ByteTrack over a video and write an annotated copy.
 
-    # Initialize Tracker
-    # track_thresh=0.1, track_buffer=30, match_thresh=0.8, det_thresh=0.1
-    tracker = trackforge.BYTETRACK(0.1, 30, 0.8, 0.1)
-
-    # Open Video
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        print(f"Error opening video file {video_path}")
-        return
-
-    # Video Writer
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-
-    # Use MP4V codec
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
-
-    frame_count = 0
-    t0 = time.time()
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
-            break
-
-        frame_count += 1
-
-        # Run Detection
-        results = model.predict(frame, verbose=False)
-
-        # Prepare detections for Rust tracker
-        detections_for_tracker = []
-
-        for result in results:
-            boxes = result.boxes
-            for box in boxes:
-                # get tlwh
-                xyxy = box.xyxy[0].cpu().numpy()
-                x1, y1, x2, y2 = xyxy
-                w = x2 - x1
-                h = y2 - y1
-                tlwh = [float(x1), float(y1), float(w), float(h)]
-                conf = float(box.conf[0].cpu().numpy())
-                cls = int(box.cls[0].cpu().numpy())
-
-                detections_for_tracker.append((tlwh, conf, cls))
-
-        # Update Tracker
-        # Returns list of (track_id, tlwh, score, class_id)
-        online_tracks = tracker.update(detections_for_tracker)
-
-        # Draw Tracks
-        for t in online_tracks:
-            track_id = t[0]
-            tlwh = t[1]
-            score = t[2]
-            class_id = t[3]
-
-            x1, y1, w, h = tlwh
-            x2 = x1 + w
-            y2 = y1 + h
-
-            # Draw box
-            color = (0, 255, 0)  # Green
-            cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
-
-            # Draw Label
-            label = f"ID: {track_id} {model.names[class_id]} {score:.2f}"
-            cv2.putText(
-                frame,
-                label,
-                (int(x1), int(y1) - 10),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.5,
-                color,
-                2,
-            )
-
-        # Draw frame count
-        cv2.putText(
-            frame,
-            f"Frame: {frame_count}",
-            (20, 40),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            1,
-            (0, 0, 255),
-            2,
-        )
-
-        out.write(frame)
-        if frame_count % 50 == 0:
-            print(f"Processed {frame_count} frames...")
-
-    t1 = time.time()
-    print(
-        f"Done. Processed {frame_count} frames in {t1 - t0:.2f}s ({(frame_count / (t1 - t0)):.1f} fps)"
+    Args:
+        video: Path to the input video.
+        output: Path for the annotated output video.
+        model_path: Path to the YOLO model weights.
+    """
+    model = YOLO(model_path)
+    tracker = trackforge.BYTETRACK(
+        track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6
     )
 
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
+    )
+
+    frame_count = 0
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        frame_count += 1
+
+        detections = yolo_detections(model, frame, classes=[0])
+        tracks = tracker.update(detections)
+        for track_id, tlwh, score, class_id in tracks:
+            draw_track(
+                frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
+            )
+
+        draw_hud(
+            frame,
+            f"ByteTrack | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
+        )
+        writer.write(frame)
+        log_progress(frame_count, info.total_frames, start)
+
     cap.release()
-    out.release()
-    print(f"Saved output video to {output_path}")
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ByteTrack tracking with YOLO detection."
+    )
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_bytetrack.mp4", help="output video path"
+    )
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_tracking(args.video, args.output, args.model)
 
 
 if __name__ == "__main__":
-    run_tracking()
+    main()

--- a/examples/python/common.py
+++ b/examples/python/common.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Shared helpers for the trackforge Python examples.
+
+Every demo in this directory reads a video, runs a detector, feeds detections
+to a trackforge tracker, draws the results, and writes an annotated video. The
+functions here factor out that shared plumbing so each demo only has to wire up
+its detector and tracker.
+
+Requirements:
+    pip install opencv-python
+"""
+
+from __future__ import annotations
+
+import time
+from typing import NamedTuple, Optional, Sequence
+
+import cv2
+
+# BGR palette cycled by track id so the same id keeps a stable color.
+PALETTE: list[tuple[int, int, int]] = [
+    (255, 0, 0),  # blue
+    (0, 255, 0),  # green
+    (0, 0, 255),  # red
+    (255, 255, 0),  # cyan
+    (255, 0, 255),  # magenta
+    (0, 255, 255),  # yellow
+    (128, 0, 255),  # purple
+    (255, 128, 0),  # orange
+]
+
+# A trackforge detection: (tlwh, score, class_id).
+Detection = tuple[list[float], float, int]
+
+
+class VideoInfo(NamedTuple):
+    """Basic properties of an opened video.
+
+    Attributes:
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        fps: Frames per second.
+        total_frames: Total frame count (0 if the backend cannot report it).
+    """
+
+    width: int
+    height: int
+    fps: int
+    total_frames: int
+
+
+def color_for(track_id: int) -> tuple[int, int, int]:
+    """Return a stable BGR color for a track id.
+
+    Args:
+        track_id: Track identifier.
+
+    Returns:
+        A BGR color tuple drawn from :data:`PALETTE`.
+    """
+    return PALETTE[track_id % len(PALETTE)]
+
+
+def label_for(track_id: int, class_name: str, score: float) -> str:
+    """Format the on-frame label shared by every demo.
+
+    Args:
+        track_id: Track identifier.
+        class_name: Human-readable class name from the detector.
+        score: Detection confidence in ``[0, 1]``.
+
+    Returns:
+        A label string of the form ``"ID:3 person 0.87"``.
+    """
+    return f"ID:{track_id} {class_name} {score:.2f}"
+
+
+def load_video(video_path: str) -> tuple[cv2.VideoCapture, VideoInfo]:
+    """Open a video file and read its properties.
+
+    Args:
+        video_path: Path to the input video.
+
+    Returns:
+        A tuple of the open capture and its :class:`VideoInfo`.
+
+    Raises:
+        FileNotFoundError: If the video cannot be opened.
+    """
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise FileNotFoundError(f"could not open video: {video_path}")
+
+    info = VideoInfo(
+        width=int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)),
+        height=int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+        fps=int(cap.get(cv2.CAP_PROP_FPS)) or 30,
+        total_frames=int(cap.get(cv2.CAP_PROP_FRAME_COUNT)),
+    )
+    return cap, info
+
+
+def create_video_writer(
+    output_path: str, info: VideoInfo, width: Optional[int] = None
+) -> cv2.VideoWriter:
+    """Create an MP4 writer matched to a video's size and frame rate.
+
+    Args:
+        output_path: Path for the annotated output video.
+        info: Source video properties.
+        width: Override output width (used by side-by-side comparisons).
+
+    Returns:
+        An opened ``cv2.VideoWriter``.
+    """
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    size = (width or info.width, info.height)
+    return cv2.VideoWriter(output_path, fourcc, info.fps, size)
+
+
+def yolo_detections(
+    model, frame, classes: Optional[Sequence[int]] = None
+) -> list[Detection]:
+    """Run an Ultralytics YOLO model and convert boxes to trackforge detections.
+
+    Args:
+        model: A loaded ``ultralytics.YOLO`` model.
+        frame: BGR image frame from OpenCV.
+        classes: Optional class ids to keep (``None`` keeps all classes).
+
+    Returns:
+        A list of ``(tlwh, score, class_id)`` detections.
+    """
+    results = model.predict(frame, verbose=False, classes=classes)
+    detections: list[Detection] = []
+    for result in results:
+        for box in result.boxes:
+            x1, y1, x2, y2 = box.xyxy[0].cpu().numpy()
+            tlwh = [float(x1), float(y1), float(x2 - x1), float(y2 - y1)]
+            score = float(box.conf[0].cpu().numpy())
+            class_id = int(box.cls[0].cpu().numpy())
+            detections.append((tlwh, score, class_id))
+    return detections
+
+
+def draw_track(
+    frame,
+    track_id: int,
+    tlwh: Sequence[float],
+    label: str,
+    color: Optional[tuple[int, int, int]] = None,
+) -> None:
+    """Draw one track's box and a filled label onto a frame in place.
+
+    Args:
+        frame: BGR image frame to draw on.
+        track_id: Track identifier (selects the color when ``color`` is None).
+        tlwh: Bounding box as ``[x, y, w, h]``.
+        label: Text to render above the box.
+        color: Optional BGR override; defaults to :func:`color_for`.
+    """
+    if color is None:
+        color = color_for(track_id)
+
+    x, y, w, h = (int(v) for v in tlwh)
+    cv2.rectangle(frame, (x, y), (x + w, y + h), color, 2)
+
+    (text_w, text_h), _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 2)
+    cv2.rectangle(frame, (x, y - text_h - 10), (x + text_w, y), color, -1)
+    cv2.putText(
+        frame,
+        label,
+        (x, y - 5),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.5,
+        (255, 255, 255),
+        2,
+    )
+
+
+def draw_hud(frame, text: str) -> None:
+    """Draw a heads-up banner (tracker name, frame index, track count).
+
+    Args:
+        frame: BGR image frame to draw on.
+        text: Banner text rendered near the top-left corner.
+    """
+    cv2.putText(frame, text, (20, 40), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2)
+
+
+def log_progress(
+    frame_count: int, total_frames: int, start_time: float, every: int = 50
+) -> None:
+    """Print a throughput line every ``every`` frames.
+
+    Args:
+        frame_count: Frames processed so far.
+        total_frames: Total frames in the video (0 if unknown).
+        start_time: ``time.time()`` captured before the loop started.
+        every: Print cadence in frames.
+    """
+    if frame_count % every:
+        return
+    elapsed = time.time() - start_time
+    fps = frame_count / elapsed if elapsed else 0.0
+    total = total_frames or "?"
+    print(f"  processed {frame_count}/{total} frames ({fps:.1f} fps)")

--- a/examples/python/deep_ocsort_demo.py
+++ b/examples/python/deep_ocsort_demo.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Deep SORT tracking demo with YOLO detection and ResNet18 appearance features.
+"""Deep OC-SORT tracking demo with YOLO detection and ResNet18 appearance features.
+
+Deep OC-SORT blends OC-SORT motion (IoU + velocity direction) with an appearance
+affinity term. Pass ``--no-reid`` to run on motion alone (pure OC-SORT behavior).
 
 Requirements:
     pip install ultralytics opencv-python trackforge torch torchvision pillow
 
 Example:
-    $ python deepsort_demo.py --video people.mp4 --model yolo11n.pt
+    $ python deep_ocsort_demo.py --video people.mp4 --model yolo11n.pt
 """
 
 from __future__ import annotations
@@ -26,26 +29,35 @@ from common import (
     log_progress,
     yolo_detections,
 )
-from reid import extract_features, get_embedder
 
 
-def run_tracking(video: str, output: str, model_path: str) -> None:
-    """Run Deep SORT over a video and write an annotated copy.
+def run_tracking(video: str, output: str, model_path: str, use_reid: bool) -> None:
+    """Run Deep OC-SORT over a video and write an annotated copy.
 
     Args:
         video: Path to the input video.
         output: Path for the annotated output video.
         model_path: Path to the YOLO model weights.
+        use_reid: When True, extract ResNet18 embeddings for appearance matching;
+            when False, track on motion alone.
     """
     model = YOLO(model_path)
-    embedder, transform = get_embedder()
-    tracker = trackforge.DEEPSORT(
+    tracker = trackforge.DEEPOCSORT(
         max_age=30,
-        n_init=3,
-        max_iou_distance=0.7,
+        min_hits=3,
+        iou_threshold=0.3,
+        delta_t=3,
+        inertia=0.2,
+        appearance_weight=0.5,
         max_cosine_distance=0.2,
         nn_budget=100,
     )
+
+    embedder = transform = None
+    if use_reid:
+        from reid import extract_features, get_embedder
+
+        embedder, transform = get_embedder()
 
     cap, info = load_video(video)
     writer = create_video_writer(output, info)
@@ -62,9 +74,12 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
         frame_count += 1
 
         detections = yolo_detections(model, frame, classes=[0])
-        embeddings = extract_features(
-            embedder, transform, frame, [d[0] for d in detections]
-        )
+        if use_reid:
+            embeddings = extract_features(
+                embedder, transform, frame, [d[0] for d in detections]
+            )
+        else:
+            embeddings = []
         tracks = tracker.update(detections, embeddings)
         for track_id, tlwh, score, class_id in tracks:
             draw_track(
@@ -73,7 +88,7 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
 
         draw_hud(
             frame,
-            f"Deep SORT | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
+            f"Deep OC-SORT | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
         )
         writer.write(frame)
         log_progress(frame_count, info.total_frames, start)
@@ -85,19 +100,22 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Deep SORT tracking with YOLO detection and ResNet18 embeddings."
+        description="Deep OC-SORT tracking with YOLO detection and ResNet18 embeddings."
     )
     parser.add_argument("--video", default="people.mp4", help="input video path")
     parser.add_argument(
-        "--output", default="output_deepsort.mp4", help="output video path"
+        "--output", default="output_deep_ocsort.mp4", help="output video path"
     )
     parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    parser.add_argument(
+        "--no-reid", action="store_true", help="track on motion alone (skip embeddings)"
+    )
     args = parser.parse_args()
 
     if not Path(args.video).exists():
         print(f"video not found: {args.video}")
         return
-    run_tracking(args.video, args.output, args.model)
+    run_tracking(args.video, args.output, args.model, use_reid=not args.no_reid)
 
 
 if __name__ == "__main__":

--- a/examples/python/ocsort_demo.py
+++ b/examples/python/ocsort_demo.py
@@ -1,94 +1,95 @@
-import cv2
-from ultralytics import YOLO
-import trackforge
+#!/usr/bin/env python3
+"""OC-SORT tracking demo with an Ultralytics YOLO detector.
+
+Requirements:
+    pip install ultralytics opencv-python trackforge
+
+Example:
+    $ python ocsort_demo.py --video people.mp4 --model yolo11n.pt
+"""
+
+from __future__ import annotations
+
+import argparse
 import time
+from pathlib import Path
+
+from ultralytics import YOLO
+
+import trackforge
+from common import (
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    label_for,
+    load_video,
+    log_progress,
+    yolo_detections,
+)
 
 
-def run_tracking(video_path="test_video.mp4", output_path="output_ocsort.mp4"):
-    model = YOLO("yolo26n.pt")
+def run_tracking(video: str, output: str, model_path: str) -> None:
+    """Run OC-SORT over a video and write an annotated copy.
 
+    Args:
+        video: Path to the input video.
+        output: Path for the annotated output video.
+        model_path: Path to the YOLO model weights.
+    """
+    model = YOLO(model_path)
     tracker = trackforge.OCSORT(
-        max_age=30,
-        min_hits=3,
-        iou_threshold=0.3,
-        delta_t=3,
-        inertia=0.2,
+        max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inertia=0.2
     )
 
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        print(f"Error opening video file {video_path}")
-        return
-
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
+    )
 
     frame_count = 0
-    t0 = time.time()
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
             break
-
         frame_count += 1
 
-        results = model.predict(frame, verbose=False)
-
-        detections = []
-        for result in results:
-            for box in result.boxes:
-                xyxy = box.xyxy[0].cpu().numpy()
-                x1, y1, x2, y2 = xyxy
-                tlwh = [float(x1), float(y1), float(x2 - x1), float(y2 - y1)]
-                conf = float(box.conf[0].cpu().numpy())
-                cls = int(box.cls[0].cpu().numpy())
-                detections.append((tlwh, conf, cls))
-
-        online_tracks = tracker.update(detections)
-
-        for track_id, tlwh, score, class_id in online_tracks:
-            x1, y1, w, h = tlwh
-            cv2.rectangle(
-                frame, (int(x1), int(y1)), (int(x1 + w), int(y1 + h)), (0, 255, 0), 2
-            )
-            label = f"ID:{track_id} {model.names[class_id]} {score:.2f}"
-            cv2.putText(
-                frame,
-                label,
-                (int(x1), int(y1) - 10),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.5,
-                (0, 255, 0),
-                2,
+        detections = yolo_detections(model, frame, classes=[0])
+        tracks = tracker.update(detections)
+        for track_id, tlwh, score, class_id in tracks:
+            draw_track(
+                frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )
 
-        cv2.putText(
+        draw_hud(
             frame,
-            f"Frame: {frame_count}",
-            (20, 40),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            1,
-            (0, 0, 255),
-            2,
+            f"OC-SORT | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
         )
-        out.write(frame)
+        writer.write(frame)
+        log_progress(frame_count, info.total_frames, start)
 
-        if frame_count % 50 == 0:
-            print(f"Processed {frame_count} frames...")
-
-    t1 = time.time()
-    print(
-        f"Done. {frame_count} frames in {t1 - t0:.2f}s ({frame_count / (t1 - t0):.1f} fps)"
-    )
     cap.release()
-    out.release()
-    print(f"Saved output to {output_path}")
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="OC-SORT tracking with YOLO detection."
+    )
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_ocsort.mp4", help="output video path"
+    )
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_tracking(args.video, args.output, args.model)
 
 
 if __name__ == "__main__":
-    run_tracking()
+    main()

--- a/examples/python/reid.py
+++ b/examples/python/reid.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Appearance (Re-ID) embedding helper for the appearance-based demos.
+
+Deep SORT and Deep OC-SORT both need a per-detection appearance vector. This
+module wraps a generic ImageNet ResNet18 as a stand-in feature extractor so the
+demos stay focused on tracking. For real workloads swap in a Re-ID-specific
+model (OSNet, FastReID, etc.).
+
+Requirements:
+    pip install torch torchvision pillow opencv-python
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import cv2
+import numpy as np
+import torch
+import torchvision.models as models
+import torchvision.transforms as T
+from PIL import Image
+
+
+def get_embedder() -> tuple[torch.nn.Module, T.Compose]:
+    """Load a pretrained ResNet18 as a 512-dim feature extractor.
+
+    Returns:
+        A tuple of the eval-mode model (classification head removed) and the
+        preprocessing transform sized for typical Re-ID crops.
+    """
+    model = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+    model.fc = torch.nn.Identity()
+    model.eval()
+
+    transform = T.Compose(
+        [
+            T.Resize((128, 64)),
+            T.ToTensor(),
+            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+    return model, transform
+
+
+def extract_features(
+    model: torch.nn.Module,
+    transform: T.Compose,
+    frame,
+    bboxes: Sequence[Sequence[float]],
+) -> list[list[float]]:
+    """Extract L2-normalized appearance embeddings for a batch of boxes.
+
+    Args:
+        model: Feature extractor from :func:`get_embedder`.
+        transform: Matching preprocessing transform.
+        frame: BGR image frame from OpenCV.
+        bboxes: Bounding boxes in TLWH format ``[[x, y, w, h], ...]``.
+
+    Returns:
+        One embedding per box as a list of floats; empty if ``bboxes`` is empty.
+    """
+    if not bboxes:
+        return []
+
+    height, width = frame.shape[:2]
+    crops = []
+    for x, y, w, h in bboxes:
+        x1, y1 = max(0, int(x)), max(0, int(y))
+        x2, y2 = min(width, int(x + w)), min(height, int(y + h))
+        if x2 <= x1 or y2 <= y1:
+            crop = np.zeros((128, 64, 3), dtype=np.uint8)
+        else:
+            crop = cv2.cvtColor(frame[y1:y2, x1:x2], cv2.COLOR_BGR2RGB)
+        crops.append(Image.fromarray(crop))
+
+    batch = torch.stack([transform(img) for img in crops])
+    with torch.no_grad():
+        features = model(batch)
+    features = torch.nn.functional.normalize(features, p=2, dim=1)
+    return features.numpy().tolist()

--- a/examples/python/sort_rtdetr_demo.py
+++ b/examples/python/sort_rtdetr_demo.py
@@ -1,30 +1,39 @@
 #!/usr/bin/env python3
-"""
-SORT Tracking Example with RT-DETR from Transformers
+"""SORT tracking demo with an RT-DETR detector from Hugging Face Transformers.
 
-This example demonstrates using the SORT tracker with RT-DETR (Real-Time DEtection TRansformer)
-from Hugging Face Transformers for multi-object tracking on video.
-
-RT-DETR is a real-time end-to-end object detector that achieves state-of-the-art
-performance while maintaining high inference speed.
+RT-DETR is a real-time end-to-end transformer detector. This demo mirrors the
+YOLO demos but swaps in RT-DETR for detection.
 
 Requirements:
-    pip install transformers torch opencv-python trackforge pillow
+    pip install transformers torch pillow opencv-python trackforge
 
-Usage:
-    python sort_rtdetr_demo.py
+Example:
+    $ python sort_rtdetr_demo.py --video people.mp4 --model PekingU/rtdetr_r50vd
 """
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
 
 import cv2
 import torch
 from PIL import Image
 from transformers import RTDetrForObjectDetection, RTDetrImageProcessor
+
 import trackforge
-import time
-from pathlib import Path
+from common import (
+    Detection,
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    label_for,
+    load_video,
+    log_progress,
+)
 
-
-# COCO class names for RT-DETR
+# COCO class ids used by RT-DETR; index 0 is "person".
 COCO_CLASSES = [
     "person",
     "bicycle",
@@ -109,194 +118,127 @@ COCO_CLASSES = [
 ]
 
 
-def run_tracking(
-    video_path: str = "people.mp4",
-    output_path: str = "output_sort_rtdetr.mp4",
-    model_name: str = "PekingU/rtdetr_r50vd",
-    confidence_threshold: float = 0.5,
-    target_classes: list = None,  # None means all classes, [0] means only person
+def pick_device() -> str:
+    """Return the best available torch device (cuda, mps, or cpu)."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def rtdetr_detections(
+    model, processor, device, frame, width, height, threshold, classes
 ):
-    """
-    Run SORT tracking with RT-DETR detection on a video.
+    """Run RT-DETR and convert its output to trackforge detections.
 
     Args:
-        video_path: Path to input video file.
-        output_path: Path for output video with tracking annotations.
-        model_name: Hugging Face model name for RT-DETR.
-        confidence_threshold: Minimum confidence for detections.
-        target_classes: List of class indices to track (None for all).
-    """
-    # Set device
-    device = (
-        "cuda"
-        if torch.cuda.is_available()
-        else "mps"
-        if torch.backends.mps.is_available()
-        else "cpu"
-    )
-    print(f"🖥️  Using device: {device}")
+        model: Loaded ``RTDetrForObjectDetection``.
+        processor: Matching ``RTDetrImageProcessor``.
+        device: Torch device string.
+        frame: BGR image frame from OpenCV.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        threshold: Minimum detection confidence.
+        classes: Class ids to keep, or None for all.
 
-    # Load RT-DETR model from Transformers
-    print(f"🚀 Loading RT-DETR model: {model_name}")
-    image_processor = RTDetrImageProcessor.from_pretrained(model_name)
+    Returns:
+        A list of ``(tlwh, score, class_id)`` detections.
+    """
+    pil_image = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+    with torch.no_grad():
+        inputs = processor(images=pil_image, return_tensors="pt").to(device)
+        outputs = model(**inputs)
+    results = processor.post_process_object_detection(
+        outputs,
+        target_sizes=torch.tensor([[height, width]]).to(device),
+        threshold=threshold,
+    )[0]
+
+    detections: list[Detection] = []
+    for score, label, box in zip(
+        results["scores"], results["labels"], results["boxes"]
+    ):
+        class_id = int(label.item())
+        if classes is not None and class_id not in classes:
+            continue
+        x1, y1, x2, y2 = box.cpu().numpy()
+        tlwh = [float(x1), float(y1), float(x2 - x1), float(y2 - y1)]
+        detections.append((tlwh, float(score.item()), class_id))
+    return detections
+
+
+def run_tracking(video: str, output: str, model_name: str) -> None:
+    """Run SORT with RT-DETR detection over a video and write an annotated copy.
+
+    Args:
+        video: Path to the input video.
+        output: Path for the annotated output video.
+        model_name: Hugging Face model id for RT-DETR.
+    """
+    device = pick_device()
+    print(f"device: {device}")
+    processor = RTDetrImageProcessor.from_pretrained(model_name)
     model = RTDetrForObjectDetection.from_pretrained(model_name).to(device)
     model.eval()
-
-    # Initialize SORT Tracker
-    print("📦 Initializing SORT tracker...")
     tracker = trackforge.SORT(max_age=30, min_hits=3, iou_threshold=0.3)
 
-    # Open Video
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        print(f"❌ Error opening video file: {video_path}")
-        return
-
-    # Get video properties
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-    print(f"📹 Video: {width}x{height} @ {fps}fps, {total_frames} frames")
-
-    # Video Writer
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
+    )
 
     frame_count = 0
-    t0 = time.time()
-
-    # Color palette for different track IDs
-    colors = [
-        (255, 0, 0),  # Blue
-        (0, 255, 0),  # Green
-        (0, 0, 255),  # Red
-        (255, 255, 0),  # Cyan
-        (255, 0, 255),  # Magenta
-        (0, 255, 255),  # Yellow
-        (128, 0, 255),  # Purple
-        (255, 128, 0),  # Orange
-    ]
-
-    print("🎬 Processing video...")
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
             break
-
         frame_count += 1
 
-        # Convert BGR to RGB for PIL
-        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        pil_image = Image.fromarray(frame_rgb)
-
-        # Run RT-DETR Detection
-        with torch.no_grad():
-            inputs = image_processor(images=pil_image, return_tensors="pt").to(device)
-            outputs = model(**inputs)
-
-        # Post-process detections
-        results = image_processor.post_process_object_detection(
-            outputs,
-            target_sizes=torch.tensor([[height, width]]).to(device),
-            threshold=confidence_threshold,
-        )[0]
-
-        # Prepare detections for SORT tracker: (tlwh, score, class_id)
-        detections = []
-        for score, label, box in zip(
-            results["scores"], results["labels"], results["boxes"]
-        ):
-            # Filter by target classes if specified
-            if target_classes is not None and label.item() not in target_classes:
-                continue
-
-            # Convert xyxy to tlwh
-            x1, y1, x2, y2 = box.cpu().numpy()
-            w = x2 - x1
-            h = y2 - y1
-            tlwh = [float(x1), float(y1), float(w), float(h)]
-            conf = float(score.cpu().numpy())
-            cls = int(label.cpu().numpy())
-            detections.append((tlwh, conf, cls))
-
-        # Update SORT Tracker
+        detections = rtdetr_detections(
+            model, processor, device, frame, info.width, info.height, 0.5, classes=[0]
+        )
         tracks = tracker.update(detections)
-
-        # Draw tracks
-        for track in tracks:
-            track_id, tlwh, score, class_id = track
-            x1, y1, w, h = tlwh
-            x2, y2 = x1 + w, y1 + h
-
-            # Get color based on track ID
-            color = colors[track_id % len(colors)]
-
-            # Get class name
-            class_name = (
+        for track_id, tlwh, score, class_id in tracks:
+            name = (
                 COCO_CLASSES[class_id]
                 if class_id < len(COCO_CLASSES)
                 else f"cls{class_id}"
             )
+            draw_track(frame, track_id, tlwh, label_for(track_id, name, score))
 
-            # Draw bounding box
-            cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
-
-            # Draw label with track ID
-            label = f"ID:{track_id} {class_name} {score:.2f}"
-            label_size, _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 2)
-            cv2.rectangle(
-                frame,
-                (int(x1), int(y1) - label_size[1] - 10),
-                (int(x1) + label_size[0], int(y1)),
-                color,
-                -1,
-            )
-            cv2.putText(
-                frame,
-                label,
-                (int(x1), int(y1) - 5),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.5,
-                (255, 255, 255),
-                2,
-            )
-
-        # Draw frame info
-        info_text = f"SORT + RT-DETR | Frame: {frame_count}/{total_frames} | Tracks: {len(tracks)}"
-        cv2.putText(
-            frame, info_text, (20, 40), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2
+        draw_hud(
+            frame,
+            f"SORT + RT-DETR | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
         )
-
-        out.write(frame)
-
-        if frame_count % 50 == 0:
-            elapsed = time.time() - t0
-            fps_actual = frame_count / elapsed
-            print(
-                f"  Processed {frame_count}/{total_frames} frames ({fps_actual:.1f} fps)"
-            )
-
-    t1 = time.time()
-    total_time = t1 - t0
-    avg_fps = frame_count / total_time
-
-    print("\n✅ Done!")
-    print(f"   Processed {frame_count} frames in {total_time:.2f}s ({avg_fps:.1f} fps)")
-    print(f"   Output saved to: {output_path}")
+        writer.write(frame)
+        log_progress(frame_count, info.total_frames, start)
 
     cap.release()
-    out.release()
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="SORT tracking with RT-DETR detection."
+    )
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_sort_rtdetr.mp4", help="output video path"
+    )
+    parser.add_argument(
+        "--model", default="PekingU/rtdetr_r50vd", help="RT-DETR model id"
+    )
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_tracking(args.video, args.output, args.model)
 
 
 if __name__ == "__main__":
-    # Check if video exists
-    video_file = Path("people.mp4")
-    if not video_file.exists():
-        print("⚠️  Video file 'people.mp4' not found in current directory.")
-        print("   Please provide a video file or update the path.")
-    else:
-        # Track only persons (class 0) for people.mp4
-        run_tracking(target_classes=[0])
+    main()

--- a/examples/python/sort_yolo_demo.py
+++ b/examples/python/sort_yolo_demo.py
@@ -1,178 +1,91 @@
 #!/usr/bin/env python3
-"""
-SORT Tracking Example with Ultralytics YOLO
-
-This example demonstrates using the SORT tracker with a YOLO model for
-multi-object tracking on video.
+"""SORT tracking demo with an Ultralytics YOLO detector.
 
 Requirements:
     pip install ultralytics opencv-python trackforge
 
-Usage:
-    python sort_yolo_demo.py
+Example:
+    $ python sort_yolo_demo.py --video people.mp4 --model yolo11n.pt
 """
 
-import cv2
-from ultralytics import YOLO
-import trackforge
+from __future__ import annotations
+
+import argparse
 import time
 from pathlib import Path
 
+from ultralytics import YOLO
 
-def run_tracking(
-    video_path: str = "people.mp4",
-    output_path: str = "output_sort_yolo.mp4",
-    model_path: str = "yolo11n.pt",
-):
-    """
-    Run SORT tracking with YOLO detection on a video.
+import trackforge
+from common import (
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    label_for,
+    load_video,
+    log_progress,
+    yolo_detections,
+)
+
+
+def run_tracking(video: str, output: str, model_path: str) -> None:
+    """Run SORT over a video and write an annotated copy.
 
     Args:
-        video_path: Path to input video file.
-        output_path: Path for output video with tracking annotations.
-        model_path: Path to YOLO model weights.
+        video: Path to the input video.
+        output: Path for the annotated output video.
+        model_path: Path to the YOLO model weights.
     """
-    print(f"🚀 Loading YOLO model: {model_path}")
     model = YOLO(model_path)
-
-    # Initialize SORT Tracker
-    # max_age=30: Keep tracks alive for 30 frames without detection
-    # min_hits=3: Require 3 consecutive detections to confirm track
-    # iou_threshold=0.3: Minimum IoU for matching
-    print("📦 Initializing SORT tracker...")
     tracker = trackforge.SORT(max_age=30, min_hits=3, iou_threshold=0.3)
 
-    # Open Video
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        print(f"❌ Error opening video file: {video_path}")
-        return
-
-    # Get video properties
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-    print(f"📹 Video: {width}x{height} @ {fps}fps, {total_frames} frames")
-
-    # Video Writer
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
+    )
 
     frame_count = 0
-    t0 = time.time()
-
-    # Color palette for different track IDs
-    colors = [
-        (255, 0, 0),  # Blue
-        (0, 255, 0),  # Green
-        (0, 0, 255),  # Red
-        (255, 255, 0),  # Cyan
-        (255, 0, 255),  # Magenta
-        (0, 255, 255),  # Yellow
-        (128, 0, 255),  # Purple
-        (255, 128, 0),  # Orange
-    ]
-
-    print("🎬 Processing video...")
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
             break
-
         frame_count += 1
 
-        # Run YOLO Detection
-        results = model.predict(
-            frame, verbose=False, classes=[0]
-        )  # Only detect persons (class 0)
-
-        # Prepare detections for SORT tracker: (tlwh, score, class_id)
-        detections = []
-        for result in results:
-            boxes = result.boxes
-            for box in boxes:
-                xyxy = box.xyxy[0].cpu().numpy()
-                x1, y1, x2, y2 = xyxy
-                w = x2 - x1
-                h = y2 - y1
-                tlwh = [float(x1), float(y1), float(w), float(h)]
-                conf = float(box.conf[0].cpu().numpy())
-                cls = int(box.cls[0].cpu().numpy())
-                detections.append((tlwh, conf, cls))
-
-        # Update SORT Tracker
-        # Returns: list of (track_id, tlwh, score, class_id)
+        detections = yolo_detections(model, frame, classes=[0])
         tracks = tracker.update(detections)
-
-        # Draw tracks
-        for track in tracks:
-            track_id, tlwh, score, class_id = track
-            x1, y1, w, h = tlwh
-            x2, y2 = x1 + w, y1 + h
-
-            # Get color based on track ID
-            color = colors[track_id % len(colors)]
-
-            # Draw bounding box
-            cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), color, 2)
-
-            # Draw label with track ID
-            label = f"ID:{track_id} {model.names[class_id]} {score:.2f}"
-            label_size, _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 2)
-            cv2.rectangle(
-                frame,
-                (int(x1), int(y1) - label_size[1] - 10),
-                (int(x1) + label_size[0], int(y1)),
-                color,
-                -1,
-            )
-            cv2.putText(
-                frame,
-                label,
-                (int(x1), int(y1) - 5),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.5,
-                (255, 255, 255),
-                2,
+        for track_id, tlwh, score, class_id in tracks:
+            draw_track(
+                frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )
 
-        # Draw frame info
-        info_text = (
-            f"SORT + YOLO | Frame: {frame_count}/{total_frames} | Tracks: {len(tracks)}"
+        draw_hud(
+            frame,
+            f"SORT | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
         )
-        cv2.putText(
-            frame, info_text, (20, 40), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 0), 2
-        )
-
-        out.write(frame)
-
-        if frame_count % 50 == 0:
-            elapsed = time.time() - t0
-            fps_actual = frame_count / elapsed
-            print(
-                f"  Processed {frame_count}/{total_frames} frames ({fps_actual:.1f} fps)"
-            )
-
-    t1 = time.time()
-    total_time = t1 - t0
-    avg_fps = frame_count / total_time
-
-    print("\n✅ Done!")
-    print(f"   Processed {frame_count} frames in {total_time:.2f}s ({avg_fps:.1f} fps)")
-    print(f"   Output saved to: {output_path}")
+        writer.write(frame)
+        log_progress(frame_count, info.total_frames, start)
 
     cap.release()
-    out.release()
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SORT tracking with YOLO detection.")
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_sort_yolo.mp4", help="output video path"
+    )
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_tracking(args.video, args.output, args.model)
 
 
 if __name__ == "__main__":
-    # Check if video exists
-    video_file = Path("people.mp4")
-    if not video_file.exists():
-        print("⚠️  Video file 'people.mp4' not found in current directory.")
-        print("   Please provide a video file or update the path.")
-    else:
-        run_tracking()
+    main()

--- a/examples/python/tracker_comparison.py
+++ b/examples/python/tracker_comparison.py
@@ -1,199 +1,107 @@
 #!/usr/bin/env python3
-"""
-Tracker Comparison: ByteTrack vs SORT
+"""Side-by-side comparison of ByteTrack and SORT on the same video.
 
-This example compares ByteTrack and SORT trackers side-by-side on the same video
-to demonstrate the differences in tracking behavior.
+Runs both trackers over identical YOLO detections and writes a double-width
+video with ByteTrack on the left and SORT on the right.
 
 Requirements:
     pip install ultralytics opencv-python trackforge
 
-Usage:
-    python tracker_comparison.py
+Example:
+    $ python tracker_comparison.py --video people.mp4 --model yolo11n.pt
 """
 
-import cv2
-from ultralytics import YOLO
-import trackforge
+from __future__ import annotations
+
+import argparse
 import time
 from pathlib import Path
 
+import cv2
+from ultralytics import YOLO
 
-def run_comparison(
-    video_path: str = "people.mp4",
-    output_path: str = "output_comparison.mp4",
-    model_path: str = "yolo11n.pt",
-):
+import trackforge
+from common import (
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    load_video,
+    log_progress,
+    yolo_detections,
+)
+
+BYTETRACK_COLOR = (0, 255, 0)  # green
+SORT_COLOR = (255, 128, 0)  # orange
+
+
+def run_comparison(video: str, output: str, model_path: str) -> None:
+    """Run ByteTrack and SORT side by side and write the combined video.
+
+    Args:
+        video: Path to the input video.
+        output: Path for the annotated side-by-side output video.
+        model_path: Path to the YOLO model weights.
     """
-    Run both ByteTrack and SORT on the same video for comparison.
-    """
-    print(f"🚀 Loading YOLO model: {model_path}")
     model = YOLO(model_path)
-
-    # Initialize both trackers
-    print("📦 Initializing trackers...")
     bytetrack = trackforge.BYTETRACK(
-        track_thresh=0.5,
-        track_buffer=30,
-        match_thresh=0.8,
-        det_thresh=0.6,
+        track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6
     )
-    sort = trackforge.SORT(
-        max_age=30,
-        min_hits=3,
-        iou_threshold=0.3,
+    sort = trackforge.SORT(max_age=30, min_hits=3, iou_threshold=0.3)
+
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info, width=info.width * 2)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
     )
-
-    # Open Video
-    cap = cv2.VideoCapture(video_path)
-    if not cap.isOpened():
-        print(f"❌ Error opening video file: {video_path}")
-        return
-
-    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS))
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-    print(f"📹 Video: {width}x{height} @ {fps}fps, {total_frames} frames")
-
-    # Create side-by-side output (double width)
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    out = cv2.VideoWriter(output_path, fourcc, fps, (width * 2, height))
 
     frame_count = 0
-    t0 = time.time()
-
-    # Colors for each tracker
-    bytetrack_color = (0, 255, 0)  # Green for ByteTrack
-    sort_color = (255, 128, 0)  # Orange for SORT
-
-    print("🎬 Processing video (ByteTrack left, SORT right)...")
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
             break
-
         frame_count += 1
 
-        # Run YOLO Detection (only persons)
-        results = model.predict(frame, verbose=False, classes=[0])
+        detections = yolo_detections(model, frame, classes=[0])
+        frame_bt, frame_sort = frame.copy(), frame.copy()
 
-        # Prepare detections
-        detections = []
-        for result in results:
-            for box in result.boxes:
-                xyxy = box.xyxy[0].cpu().numpy()
-                x1, y1, x2, y2 = xyxy
-                tlwh = [float(x1), float(y1), float(x2 - x1), float(y2 - y1)]
-                conf = float(box.conf[0].cpu().numpy())
-                cls = int(box.cls[0].cpu().numpy())
-                detections.append((tlwh, conf, cls))
-
-        # Create two copies of the frame
-        frame_bt = frame.copy()
-        frame_sort = frame.copy()
-
-        # Update ByteTrack
         bt_tracks = bytetrack.update(detections)
-        for track in bt_tracks:
-            track_id, tlwh, score, class_id = track
-            x1, y1, w, h = tlwh
-            cv2.rectangle(
-                frame_bt,
-                (int(x1), int(y1)),
-                (int(x1 + w), int(y1 + h)),
-                bytetrack_color,
-                2,
-            )
-            cv2.putText(
-                frame_bt,
-                f"ID:{track_id}",
-                (int(x1), int(y1) - 10),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.7,
-                bytetrack_color,
-                2,
+        for track_id, tlwh, _, _ in bt_tracks:
+            draw_track(
+                frame_bt, track_id, tlwh, f"ID:{track_id}", color=BYTETRACK_COLOR
             )
 
-        # Update SORT
         sort_tracks = sort.update(detections)
-        for track in sort_tracks:
-            track_id, tlwh, score, class_id = track
-            x1, y1, w, h = tlwh
-            cv2.rectangle(
-                frame_sort,
-                (int(x1), int(y1)),
-                (int(x1 + w), int(y1 + h)),
-                sort_color,
-                2,
-            )
-            cv2.putText(
-                frame_sort,
-                f"ID:{track_id}",
-                (int(x1), int(y1) - 10),
-                cv2.FONT_HERSHEY_SIMPLEX,
-                0.7,
-                sort_color,
-                2,
-            )
+        for track_id, tlwh, _, _ in sort_tracks:
+            draw_track(frame_sort, track_id, tlwh, f"ID:{track_id}", color=SORT_COLOR)
 
-        # Add labels
-        cv2.putText(
-            frame_bt,
-            f"ByteTrack | Tracks: {len(bt_tracks)}",
-            (20, 40),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.8,
-            bytetrack_color,
-            2,
-        )
-        cv2.putText(
-            frame_sort,
-            f"SORT | Tracks: {len(sort_tracks)}",
-            (20, 40),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.8,
-            sort_color,
-            2,
-        )
-
-        # Combine side-by-side
+        draw_hud(frame_bt, f"ByteTrack | tracks {len(bt_tracks)}")
+        draw_hud(frame_sort, f"SORT | tracks {len(sort_tracks)}")
         combined = cv2.hconcat([frame_bt, frame_sort])
-
-        # Add frame counter in center
-        cv2.putText(
-            combined,
-            f"Frame: {frame_count}/{total_frames}",
-            (width - 100, 40),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.8,
-            (255, 255, 255),
-            2,
-        )
-
-        out.write(combined)
-
-        if frame_count % 50 == 0:
-            elapsed = time.time() - t0
-            print(
-                f"  Processed {frame_count}/{total_frames} frames ({frame_count / elapsed:.1f} fps)"
-            )
-
-    t1 = time.time()
-    print(
-        f"\n✅ Done! Processed {frame_count} frames in {t1 - t0:.2f}s ({frame_count / (t1 - t0):.1f} fps)"
-    )
-    print(f"   Output saved to: {output_path}")
+        writer.write(combined)
+        log_progress(frame_count, info.total_frames, start)
 
     cap.release()
-    out.release()
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare ByteTrack and SORT side by side."
+    )
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_comparison.mp4", help="output video path"
+    )
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_comparison(args.video, args.output, args.model)
 
 
 if __name__ == "__main__":
-    video_file = Path("people.mp4")
-    if not video_file.exists():
-        print("⚠️  Video file 'people.mp4' not found in current directory.")
-    else:
-        run_comparison()
+    main()


### PR DESCRIPTION
Unifies the Python examples so every demo follows one template.

Adds `examples/python/common.py` with the plumbing each demo repeated: video load, MP4 writer, YOLO-to-tlwh conversion, color palette, box/label drawing, and progress logging. The ResNet18 appearance embedder moves into `examples/python/reid.py`, shared by the Deep SORT and Deep OC-SORT demos.

Every demo is rewritten on the same shape: module docstring, type-hinted `run_tracking`, `argparse` with `--video/--output/--model`, `people.mp4` default, and the same label format and palette. Adds `deep_ocsort_demo.py` (with `--no-reid` for motion-only).

Docs: rewrites the examples README, fixes the tracker class names in the snippets (they are uppercase: `SORT`, `BYTETRACK`, `DEEPSORT`), documents OC-SORT and Deep OC-SORT, adds a Deep OC-SORT row to the main README examples table, and adds a PyPI python-versions badge.
