### PR TITLE
refactor(trackers): share observation-centric track and association

### DIFF
--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -147,8 +147,6 @@ impl STrack {
 ///     println!("Track ID: {}, Box: {:?}", track.track_id, track.tlwh);
 /// }
 /// ```
-///
-/// ## Abstract
 pub struct ByteTrack {
     tracked_stracks: Vec<STrack>,
     lost_stracks: Vec<STrack>,
@@ -256,22 +254,13 @@ impl ByteTrack {
             }
         }
 
-        // Second matching
-        let mut detections_second = Vec::new();
-        for &i in &u_detection {
-            detections_second.push(detections_high[i].clone());
-        }
-        // Actually second matching is with LOW confidence detections and UNMATCHED tracks from first round (that were TRACKED, not lost)
-        // Wait, standard ByteTrack:
-        // 1. Match high_det with (tracked + lost) -> matches, u_track, u_det
-        // 2. Match low_det with (remainder of tracked from u_track)
-
-        // Let's filter u_track to separate tracked and lost
-        let mut r_tracked_stracks = Vec::new(); // these are from strack_pool indices
+        // Second matching: low-confidence detections against the tracks that were
+        // still Tracked but left unmatched by the first round.
+        let mut r_tracked_stracks = Vec::new();
         for &i in &u_track {
             let track = &strack_pool[i];
             if track.state == TrackState::Tracked {
-                r_tracked_stracks.push(track.clone()); // Need to clone or manage ownership better
+                r_tracked_stracks.push(track.clone());
             }
         }
 
@@ -301,9 +290,7 @@ impl ByteTrack {
             }
         }
 
-        // Deal with unmatched high detections -> New Tracks
-        // Correct logic: High det unmatched in FIRST step.
-        // My previous code put unmatched high indices in u_detection.
+        // Unmatched high-confidence detections above det_thresh start new tracks.
         for &i in &u_detection {
             let det = &detections_high[i];
             if det.score < self.det_thresh {
@@ -316,39 +303,26 @@ impl ByteTrack {
             activated_stracks.push(new_track);
         }
 
-        // Deal with lost tracks from first round that were NOT matched
+        // Keep first-round lost tracks alive until they exceed the buffer.
         for &i in &u_track {
             let track = &strack_pool[i];
-            if track.state == TrackState::Lost {
-                // If it was already lost and not matched in first round, it stays lost or removed
-                // We need to check if we should remove it
-                if self.frame_id - track.frame_id <= self.buffer_size {
-                    lost_stracks.push(track.clone());
-                }
+            if track.state == TrackState::Lost && self.frame_id - track.frame_id <= self.buffer_size
+            {
+                lost_stracks.push(track.clone());
             }
         }
 
-        // Update self state
+        // Commit the frame state: matched and refound tracks are active, the rest lost.
         self.tracked_stracks = activated_stracks;
         self.tracked_stracks.extend(refind_stracks);
-
-        // Removed ones
-        // In this logic, removed are implicit by not adding to tracked/lost lists?
-        // Actually we need to maintain lost_stracks list.
         self.lost_stracks = lost_stracks;
-        // Also remove duplicates if any?
-        // Basic unique check or simple assignment is fine for now.
 
-        // Output
-        let mut output_stracks = Vec::new();
-        for track in &self.tracked_stracks {
-            if track.is_activated {
-                output_stracks.push(track.clone());
-            }
-        }
-
-        // Return *tracked* stracks
-        output_stracks
+        // Output the activated tracks for this frame.
+        self.tracked_stracks
+            .iter()
+            .filter(|t| t.is_activated)
+            .cloned()
+            .collect()
     }
 }
 
@@ -452,32 +426,17 @@ mod tests {
 
     #[test]
     fn test_bytetrack_low_conf_match() {
+        // A low-confidence detection (below track_thresh) is recovered by the
+        // second association round and keeps the existing track id.
         let mut tracker = ByteTrack::new(0.6, 30, 0.8, 0.6);
         let d1 = ([10.0, 10.0, 50.0, 50.0], 0.9, 0);
         let out1 = tracker.update(vec![d1]);
         assert_eq!(out1.len(), 1);
         let id = out1[0].track_id;
 
-        // Frame 2: Low conf (below track_thresh 0.6, but above implicit low thresh)
-        // Note: Code uses 0.5 as low thresh in matches
-        let d2 = ([12.0, 12.0, 50.0, 50.0], 0.4, 0); // 0.4 < 0.6 but maybe matched?
-        // Wait, ByteTrack hardcoded 0.5 low thresh in `linear_assignment` call for second matching?
-        // In my code: `self.linear_assignment(&dists, 0.5)`
-
+        // Frame 2: same object at low confidence; second-round IoU match keeps the id.
+        let d2 = ([12.0, 12.0, 50.0, 50.0], 0.4, 0);
         let output2 = tracker.update(vec![d2]);
-        // If 0.4 < 0.5 (low thresh), it might be ignored if detections are filtered out before matching?
-        // Code: Detections are split. High >= track_thresh. Low is else.
-        // So d2 is low.
-        // Then predict.
-        // Match high -> none.
-        // Match low -> d2 is low. Matches with tracked track.
-        // Only if cost < 0.5. IoU should be high (dist low).
-
-        // Let's verify if 0.4 is kept.
-        // Assuming default logic doesn't drop low confidence completely unless very low?
-        // Standard code usually has a `filter_thresh` or similar. My `update` takes all.
-
-        // Ideally it should match.
         assert_eq!(output2.len(), 1, "Expected 1 track, got {}", output2.len());
         assert_eq!(output2[0].track_id, id);
     }

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -501,4 +501,22 @@ mod tests {
             "re-activated track retains its original ID"
         );
     }
+
+    #[test]
+    fn test_bytetrack_lost_track_kept_within_buffer() {
+        // Frame 1 activates a track. Frame 2 misses it, so it becomes Lost. Frame 3
+        // misses it again while still inside the buffer, exercising the branch that
+        // keeps a first-round lost track alive. Frame 4 re-detects it and recovers
+        // the original id from the buffer.
+        let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        let d = ([10.0, 10.0, 50.0, 100.0], 0.9_f32, 0_i64);
+        let id = tracker.update(vec![d])[0].track_id;
+
+        assert!(tracker.update(vec![]).is_empty());
+        assert!(tracker.update(vec![]).is_empty());
+
+        let out = tracker.update(vec![d]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].track_id, id, "track recovered from the lost buffer");
+    }
 }

--- a/src/trackers/common/association.rs
+++ b/src/trackers/common/association.rs
@@ -1,0 +1,97 @@
+//! Observation-centric association helpers shared by OC-SORT and Deep OC-SORT.
+//!
+//! Both trackers add the same OCM direction-consistency bonus to their IoU cost and
+//! run the same round-2 rematch on last observed positions. Only the cost blend in
+//! between differs (Deep OC-SORT mixes in appearance), so those two steps live here.
+
+use crate::trackers::common::ObsTrack;
+use crate::utils::assignment::greedy_match;
+use crate::utils::geometry::{iou_batch, xyah_to_tlwh};
+
+/// OCM direction-consistency bonus matrix (`n_trks x n_dets`).
+///
+/// For each track with a computable velocity direction, adds a bonus proportional
+/// to the cosine similarity between that direction and the direction from the
+/// track's last observation to each detection centre, scaled by `inertia` and the
+/// detection score. Tracks without a direction contribute a zero row.
+pub(crate) fn ocm_angle_bonus(
+    tracks: &[ObsTrack],
+    det_boxes: &[[f32; 4]],
+    det_scores: &[f32],
+    delta_t: usize,
+    inertia: f32,
+) -> Vec<Vec<f32>> {
+    let n_dets = det_boxes.len();
+    let mut angle_diff = vec![vec![0.0_f32; n_dets]; tracks.len()];
+
+    for (i, track) in tracks.iter().enumerate() {
+        let vel_dir = match track.obs_direction(delta_t) {
+            Some(v) => v,
+            None => continue,
+        };
+        let last = track.last_observation();
+        let (last_cx, last_cy) = (last[0], last[1]);
+        for (j, det) in det_boxes.iter().enumerate() {
+            let det_cx = det[0] + det[2] / 2.0;
+            let det_cy = det[1] + det[3] / 2.0;
+            let dy = det_cy - last_cy;
+            let dx = det_cx - last_cx;
+            let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
+            let dot = (vel_dir[0] * (dy / norm) + vel_dir[1] * (dx / norm)).clamp(-1.0, 1.0);
+            let angle = dot.acos();
+            let normalized = (std::f32::consts::FRAC_PI_2 - angle.abs()) / std::f32::consts::PI;
+            angle_diff[i][j] = (normalized * inertia * det_scores[j]).max(0.0);
+        }
+    }
+    angle_diff
+}
+
+/// Round-2 rematch on last observed positions.
+///
+/// For detections and tracks left unmatched by round 1, rematches them by IoU using
+/// each track's last *observed* box rather than its Kalman prediction. Appends the
+/// new pairs to `matches` (as global `(det, trk)` indices) and shrinks the unmatched
+/// lists in place. Does nothing unless some pair reaches `iou_threshold`.
+pub(crate) fn last_observation_rematch(
+    tracks: &[ObsTrack],
+    det_boxes: &[[f32; 4]],
+    matches: &mut Vec<(usize, usize)>,
+    unmatched_dets: &mut Vec<usize>,
+    unmatched_trks: &mut Vec<usize>,
+    iou_threshold: f32,
+) {
+    if unmatched_dets.is_empty() || unmatched_trks.is_empty() {
+        return;
+    }
+
+    let left_det_boxes: Vec<[f32; 4]> = unmatched_dets.iter().map(|&di| det_boxes[di]).collect();
+    let left_trk_obs: Vec<[f32; 4]> = unmatched_trks
+        .iter()
+        .map(|&ti| xyah_to_tlwh(tracks[ti].last_observation()))
+        .collect();
+
+    let iou_left = iou_batch(&left_trk_obs, &left_det_boxes);
+    let max_iou = iou_left
+        .iter()
+        .flat_map(|r| r.iter())
+        .cloned()
+        .fold(f32::NEG_INFINITY, f32::max);
+    if max_iou <= iou_threshold {
+        return;
+    }
+
+    // Rows are tracks, columns are detections.
+    let cost_left: Vec<Vec<f32>> = iou_left
+        .iter()
+        .map(|row| row.iter().map(|&v| 1.0 - v).collect())
+        .collect();
+    let (r2_matches, r2_ut, r2_ud) = greedy_match(&cost_left, 1.0 - iou_threshold);
+
+    for (trk_local, det_local) in r2_matches {
+        matches.push((unmatched_dets[det_local], unmatched_trks[trk_local]));
+    }
+    let new_dets: Vec<usize> = r2_ud.into_iter().map(|di| unmatched_dets[di]).collect();
+    let new_trks: Vec<usize> = r2_ut.into_iter().map(|ti| unmatched_trks[ti]).collect();
+    *unmatched_dets = new_dets;
+    *unmatched_trks = new_trks;
+}

--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -5,11 +5,21 @@
 //! the predict/update mechanics they all repeat. [`cmc`] holds the shared camera
 //! motion compensation transform.
 
+pub mod association;
 pub mod cmc;
+pub mod obs_track;
 
 pub use cmc::CameraMotion;
+pub use obs_track::ObsTrack;
 
 use crate::utils::geometry::xyah_to_tlwh;
+
+/// A track as returned to Python: `(track_id, tlwh, score, class_id)`.
+///
+/// Every Python binding maps its confirmed tracks into this shape, so the type is
+/// shared here rather than redeclared per tracker.
+#[cfg(feature = "python")]
+pub type PyTrackingResult = (u64, [f32; 4], f32, i64);
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
 
 /// Lifecycle state of a track.

--- a/src/trackers/common/obs_track.rs
+++ b/src/trackers/common/obs_track.rs
@@ -1,16 +1,22 @@
-//! Per-track state for Deep OC-SORT: OC-SORT motion plus an appearance buffer.
+//! Observation-centric Kalman track shared by OC-SORT and Deep OC-SORT.
+//!
+//! Both trackers keep the same per-track state: the [`KalmanTrack`] filter, the
+//! usual lifecycle counters, and a bounded history of past observations used for
+//! velocity direction (OCM), re-update on re-association (ORU), and round-2
+//! rematching on the last observed box. Deep OC-SORT additionally buffers
+//! appearance embeddings in `pending_features`; OC-SORT leaves that buffer empty.
+//! Keeping one type here means the observation-centric mechanics live in a single
+//! tested place.
 
 use crate::trackers::common::{CameraMotion, KalmanTrack, TrackState};
 use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
 use crate::utils::kalman::{KalmanFilter, MeasurementVector};
 
-/// A single tracked object managed by Deep OC-SORT.
+/// A tracked object with an observation history.
 ///
-/// Carries the OC-SORT motion state (Kalman filter plus an observation history for
-/// OCM and ORU) and a small buffer of appearance embeddings that are flushed into
-/// the tracker's feature gallery after each matched update.
+/// Shared by OC-SORT and Deep OC-SORT (each re-exports it under its own name).
 #[derive(Debug, Clone)]
-pub struct DeepOcSortTrack {
+pub struct ObsTrack {
     /// Bounding box in TLWH (top-left x, top-left y, width, height) format.
     pub tlwh: [f32; 4],
     /// Detection confidence of the most recent match.
@@ -31,14 +37,15 @@ pub struct DeepOcSortTrack {
     pub age: usize,
 
     kalman: KalmanTrack,
-    // Circular observation history (xyah, frame_id) used for OCV and ORU.
+    // Bounded observation history (xyah, frame_id) in insertion order, used for OCM and ORU.
     observations: Vec<(MeasurementVector, usize)>,
-    // Appearance embeddings collected since the last gallery flush.
+    // Appearance embeddings collected since the last gallery flush (Deep OC-SORT only).
     pending_features: Vec<Vec<f32>>,
 }
 
-impl DeepOcSortTrack {
-    pub(super) fn new(
+impl ObsTrack {
+    /// Create a track from a first detection, optionally seeding an appearance feature.
+    pub(crate) fn new(
         tlwh: [f32; 4],
         score: f32,
         class_id: i64,
@@ -49,8 +56,6 @@ impl DeepOcSortTrack {
     ) -> Self {
         let xyah = tlwh_to_xyah(&tlwh);
         let kalman = KalmanTrack::initiate(&xyah, kf);
-        let observations = vec![(xyah, frame_id)];
-        let pending_features = feature.into_iter().collect();
 
         Self {
             tlwh,
@@ -63,13 +68,13 @@ impl DeepOcSortTrack {
             time_since_update: 0,
             age: 1,
             kalman,
-            observations,
-            pending_features,
+            observations: vec![(xyah, frame_id)],
+            pending_features: feature.into_iter().collect(),
         }
     }
 
     /// Kalman-predict one step forward, resetting `hit_streak` after a missed frame.
-    pub(super) fn predict(&mut self, kf: &KalmanFilter) {
+    pub(crate) fn predict(&mut self, kf: &KalmanFilter) {
         if self.time_since_update > 0 {
             self.hit_streak = 0;
         }
@@ -79,13 +84,23 @@ impl DeepOcSortTrack {
     }
 
     /// Standard Kalman update with a matched detection in XYAH form.
-    pub(super) fn update_kf(&mut self, xyah: &MeasurementVector, kf: &KalmanFilter) {
+    pub(crate) fn update_kf(&mut self, xyah: &MeasurementVector, kf: &KalmanFilter) {
         self.kalman.update(xyah, kf);
         self.tlwh = xyah_to_tlwh(&self.kalman.mean);
     }
 
+    /// Copy a matched detection's box/score/class and bump the hit counters.
+    pub(crate) fn record_match(&mut self, tlwh: [f32; 4], score: f32, class_id: i64) {
+        self.tlwh = tlwh;
+        self.score = score;
+        self.class_id = class_id;
+        self.hits += 1;
+        self.hit_streak += 1;
+        self.time_since_update = 0;
+    }
+
     /// Warp the predicted state and observation history by a camera motion transform.
-    pub(super) fn apply_camera_motion(&mut self, cmc: &CameraMotion) {
+    pub(crate) fn apply_camera_motion(&mut self, cmc: &CameraMotion) {
         self.tlwh = self.kalman.apply_camera_motion(cmc);
         for (obs, _) in &mut self.observations {
             cmc.apply_observation(obs);
@@ -95,7 +110,7 @@ impl DeepOcSortTrack {
     /// OCV: normalised `[dy, dx]` velocity direction over the last `delta_t` frames.
     ///
     /// Returns `None` when fewer than two observations are available.
-    pub(super) fn obs_direction(&self, delta_t: usize) -> Option<[f32; 2]> {
+    pub(crate) fn obs_direction(&self, delta_t: usize) -> Option<[f32; 2]> {
         let n = self.observations.len();
         if n < 2 {
             return None;
@@ -109,8 +124,8 @@ impl DeepOcSortTrack {
         Some([dy / norm, dx / norm])
     }
 
-    /// Last observed centre `(cx, cy)`; used by the OCM bonus and round-2 re-match.
-    pub(super) fn last_observation(&self) -> &MeasurementVector {
+    /// Last observed centre `(cx, cy, a, h)`; used by the OCM bonus and round-2 re-match.
+    pub(crate) fn last_observation(&self) -> &MeasurementVector {
         &self
             .observations
             .last()
@@ -119,7 +134,7 @@ impl DeepOcSortTrack {
     }
 
     /// ORU: replay interpolated observations to correct KF drift after re-association.
-    pub(super) fn our_re_update(
+    pub(crate) fn our_re_update(
         &mut self,
         current_xyah: &MeasurementVector,
         current_frame: usize,
@@ -134,6 +149,7 @@ impl DeepOcSortTrack {
             return;
         }
 
+        // Interpolate in TLWH space (matching the reference), replaying predict/update.
         let last_tlwh = xyah_to_tlwh(last_obs);
         let current_tlwh = xyah_to_tlwh(current_xyah);
         let (mut mean, mut covariance) = kf.initiate(last_obs);
@@ -161,7 +177,7 @@ impl DeepOcSortTrack {
     }
 
     /// Record a new observation, keeping the history bounded to `max_obs` entries.
-    pub(super) fn push_observation(
+    pub(crate) fn push_observation(
         &mut self,
         xyah: MeasurementVector,
         frame_id: usize,
@@ -174,20 +190,21 @@ impl DeepOcSortTrack {
     }
 
     /// Buffer an appearance embedding to be flushed into the gallery this frame.
-    pub(super) fn push_feature(&mut self, feature: Vec<f32>) {
+    pub(crate) fn push_feature(&mut self, feature: Vec<f32>) {
         self.pending_features.push(feature);
     }
 
     /// Drain the buffered embeddings collected since the last flush.
-    pub(super) fn take_features(&mut self) -> Vec<Vec<f32>> {
+    pub(crate) fn take_features(&mut self) -> Vec<Vec<f32>> {
         std::mem::take(&mut self.pending_features)
     }
 
-    pub(super) fn mark_deleted(&mut self) {
+    pub(crate) fn mark_deleted(&mut self) {
         self.state = TrackState::Deleted;
     }
 
-    pub(super) fn is_confirmed(&self) -> bool {
+    /// Whether the track has been confirmed and is returned to callers.
+    pub fn is_confirmed(&self) -> bool {
         self.state == TrackState::Confirmed
     }
 }
@@ -196,9 +213,9 @@ impl DeepOcSortTrack {
 mod tests {
     use super::*;
 
-    fn make_track() -> DeepOcSortTrack {
+    fn make_track() -> ObsTrack {
         let kf = KalmanFilter::default();
-        DeepOcSortTrack::new(
+        ObsTrack::new(
             [100.0, 100.0, 50.0, 100.0],
             0.9,
             0,
@@ -224,7 +241,6 @@ mod tests {
         for frame in 2..12 {
             track.push_observation(tlwh_to_xyah(&[100.0, 100.0, 50.0, 100.0]), frame, 4);
         }
-        // History stays bounded, so a direction is still computable without panic.
         assert!(track.obs_direction(3).is_some());
     }
 
@@ -243,7 +259,19 @@ mod tests {
     fn take_features_drains_buffer() {
         let mut track = make_track();
         track.push_feature(vec![0.5, 0.5]);
+        // new() seeded one feature, push_feature added another.
         assert_eq!(track.take_features().len(), 2);
         assert!(track.take_features().is_empty());
+    }
+
+    #[test]
+    fn record_match_bumps_counters() {
+        let mut track = make_track();
+        track.predict(&KalmanFilter::default());
+        track.record_match([120.0, 100.0, 50.0, 100.0], 0.8, 2);
+        assert_eq!(track.tlwh, [120.0, 100.0, 50.0, 100.0]);
+        assert_eq!(track.class_id, 2);
+        assert_eq!(track.hits, 2);
+        assert_eq!(track.time_since_update, 0);
     }
 }

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -1,12 +1,18 @@
 #![doc = include_str!("README.md")]
 
-mod track;
 mod tracker;
 
 #[cfg(feature = "python")]
 pub mod python;
 
-pub use track::DeepOcSortTrack;
+/// A single tracked object managed by Deep OC-SORT.
+///
+/// Alias of the shared observation-centric [`ObsTrack`], which carries the Kalman
+/// state, observation history (OCM/ORU), and the appearance-embedding buffer Deep
+/// OC-SORT flushes into its feature gallery.
+///
+/// [`ObsTrack`]: crate::trackers::common::ObsTrack
+pub use crate::trackers::common::ObsTrack as DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
 use crate::trackers::common::CameraMotion;

--- a/src/trackers/deep_ocsort/python.rs
+++ b/src/trackers/deep_ocsort/python.rs
@@ -1,8 +1,6 @@
 use super::DeepOcSortTracker;
-use crate::trackers::common::CameraMotion;
+use crate::trackers::common::{CameraMotion, PyTrackingResult};
 use pyo3::prelude::*;
-
-type PyTrackingResult = (u64, [f32; 4], f32, i64);
 
 /// Python-exposed Deep OC-SORT tracker.
 #[pyclass(name = "DEEPOCSORT")]

--- a/src/trackers/deep_ocsort/tracker.rs
+++ b/src/trackers/deep_ocsort/tracker.rs
@@ -1,10 +1,10 @@
 //! Deep OC-SORT association: OC-SORT motion plus an appearance affinity term.
 
-use super::track::DeepOcSortTrack;
-use crate::trackers::common::CameraMotion;
+use crate::trackers::common::association::{last_observation_rematch, ocm_angle_bonus};
+use crate::trackers::common::{CameraMotion, ObsTrack as DeepOcSortTrack, TrackState};
 use crate::trackers::deepsort::NearestNeighborDistanceMetric;
 use crate::utils::assignment::greedy_match;
-use crate::utils::geometry::{iou_batch, tlwh_to_xyah, xyah_to_tlwh};
+use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
 use crate::utils::kalman::KalmanFilter;
 use std::collections::HashSet;
 
@@ -120,13 +120,7 @@ impl DeepOcSortTracker {
             }
             track.update_kf(&xyah, &self.kf);
             track.push_observation(xyah, self.frame_count, self.delta_t + 1);
-
-            track.tlwh = det.tlwh;
-            track.score = det.score;
-            track.class_id = det.class_id;
-            track.hits += 1;
-            track.hit_streak += 1;
-            track.time_since_update = 0;
+            track.record_match(det.tlwh, det.score, det.class_id);
 
             if use_appearance {
                 track.push_feature(embeddings[*det_idx].clone());
@@ -151,7 +145,7 @@ impl DeepOcSortTracker {
 
         for track in &mut self.tracks {
             if track.time_since_update == 0 && track.hit_streak >= self.min_hits {
-                track.state = crate::trackers::common::TrackState::Confirmed;
+                track.state = TrackState::Confirmed;
             }
             if track.time_since_update > self.max_age {
                 track.mark_deleted();
@@ -160,15 +154,12 @@ impl DeepOcSortTracker {
 
         let unmatched_set: HashSet<usize> = unmatched_trks.into_iter().collect();
         for (i, track) in self.tracks.iter_mut().enumerate() {
-            if unmatched_set.contains(&i)
-                && track.state == crate::trackers::common::TrackState::Tentative
-            {
+            if unmatched_set.contains(&i) && track.state == TrackState::Tentative {
                 track.mark_deleted();
             }
         }
 
-        self.tracks
-            .retain(|t| t.state != crate::trackers::common::TrackState::Deleted);
+        self.tracks.retain(|t| t.state != TrackState::Deleted);
 
         self.flush_gallery();
 
@@ -218,29 +209,16 @@ impl DeepOcSortTracker {
 
         let pred_boxes: Vec<[f32; 4]> = self.tracks.iter().map(|t| t.tlwh).collect();
         let det_boxes: Vec<[f32; 4]> = detections.iter().map(|d| d.tlwh).collect();
-        let ious = iou_batch(&pred_boxes, &det_boxes);
+        let det_scores: Vec<f32> = detections.iter().map(|d| d.score).collect();
 
-        // OCM direction-consistency bonus, identical to OC-SORT.
-        let mut angle_diff: Vec<Vec<f32>> = vec![vec![0.0_f32; n_dets]; n_trks];
-        for (i, track) in self.tracks.iter().enumerate() {
-            let vel_dir = match track.obs_direction(self.delta_t) {
-                Some(v) => v,
-                None => continue,
-            };
-            let last = track.last_observation();
-            let (last_cx, last_cy) = (last[0], last[1]);
-            for (j, det) in detections.iter().enumerate() {
-                let det_cx = det.tlwh[0] + det.tlwh[2] / 2.0;
-                let det_cy = det.tlwh[1] + det.tlwh[3] / 2.0;
-                let dy = det_cy - last_cy;
-                let dx = det_cx - last_cx;
-                let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
-                let dot = (vel_dir[0] * (dy / norm) + vel_dir[1] * (dx / norm)).clamp(-1.0, 1.0);
-                let angle = dot.acos();
-                let normalized = (std::f32::consts::FRAC_PI_2 - angle.abs()) / std::f32::consts::PI;
-                angle_diff[i][j] = (normalized * self.inertia * det.score).max(0.0);
-            }
-        }
+        let ious = iou_batch(&pred_boxes, &det_boxes);
+        let angle_diff = ocm_angle_bonus(
+            &self.tracks,
+            &det_boxes,
+            &det_scores,
+            self.delta_t,
+            self.inertia,
+        );
 
         // Appearance cost matrix (n_trks x n_dets) of cosine distances, or empty.
         let app_cost = if use_appearance {
@@ -250,6 +228,7 @@ impl DeepOcSortTracker {
             Vec::new()
         };
 
+        // Round 1: motion (IoU + OCM) blended with the gated appearance cost.
         let cost_matrix: Vec<Vec<f32>> = (0..n_trks)
             .map(|i| {
                 (0..n_dets)
@@ -268,43 +247,22 @@ impl DeepOcSortTracker {
             })
             .collect();
 
-        let (matches_td, mut unmatched_trks, mut unmatched_dets) =
+        let (matches_raw, mut unmatched_trks, mut unmatched_dets) =
             greedy_match(&cost_matrix, 1.0 - self.iou_threshold);
-        let mut matches: Vec<(usize, usize)> = matches_td
+        let mut matches: Vec<(usize, usize)> = matches_raw
             .into_iter()
             .map(|(trk, det)| (det, trk))
             .collect();
 
         // Round 2: motion-only re-match on last observed positions.
-        if !unmatched_dets.is_empty() && !unmatched_trks.is_empty() {
-            let left_det_boxes: Vec<[f32; 4]> = unmatched_dets
-                .iter()
-                .map(|&di| detections[di].tlwh)
-                .collect();
-            let left_trk_obs: Vec<[f32; 4]> = unmatched_trks
-                .iter()
-                .map(|&ti| xyah_to_tlwh(self.tracks[ti].last_observation()))
-                .collect();
-            let iou_left = iou_batch(&left_trk_obs, &left_det_boxes);
-            let max_iou = iou_left
-                .iter()
-                .flat_map(|r| r.iter())
-                .cloned()
-                .fold(f32::NEG_INFINITY, f32::max);
-
-            if max_iou > self.iou_threshold {
-                let cost_left: Vec<Vec<f32>> = iou_left
-                    .iter()
-                    .map(|row| row.iter().map(|&v| 1.0 - v).collect())
-                    .collect();
-                let (r2_matches, r2_ut, r2_ud) = greedy_match(&cost_left, 1.0 - self.iou_threshold);
-                for (trk_local, det_local) in r2_matches {
-                    matches.push((unmatched_dets[det_local], unmatched_trks[trk_local]));
-                }
-                unmatched_dets = r2_ud.into_iter().map(|di| unmatched_dets[di]).collect();
-                unmatched_trks = r2_ut.into_iter().map(|ti| unmatched_trks[ti]).collect();
-            }
-        }
+        last_observation_rematch(
+            &self.tracks,
+            &det_boxes,
+            &mut matches,
+            &mut unmatched_dets,
+            &mut unmatched_trks,
+            self.iou_threshold,
+        );
 
         (matches, unmatched_dets, unmatched_trks)
     }

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -419,16 +419,8 @@ mod tests {
         track.push_observation(tlwh_to_xyah(&tlwh2), 2, 4);
 
         let dir = track.obs_direction(3).unwrap();
-        assert!(
-            dir[0].abs() < 0.01,
-            "Expected dy direction ~0.0, got {}",
-            dir[0]
-        );
-        assert!(
-            (dir[1] - 1.0).abs() < 0.01,
-            "Expected dx direction ~1.0, got {}",
-            dir[1]
-        );
+        assert!(dir[0].abs() < 0.01);
+        assert!((dir[1] - 1.0).abs() < 0.01);
     }
 
     #[test]

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -1,202 +1,30 @@
 #![doc = include_str!("README.md")]
 
-use crate::trackers::common::{KalmanTrack, TrackState};
-use crate::utils::geometry::{tlwh_to_xyah, xyah_to_tlwh};
-use crate::utils::kalman::{KalmanFilter, MeasurementVector};
+use crate::trackers::common::association::{last_observation_rematch, ocm_angle_bonus};
+use crate::trackers::common::{ObsTrack, TrackState};
+use crate::utils::assignment::greedy_match;
+use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
 use std::collections::HashSet;
-
-// ---------------------------------------------------------------------------
-// Track state
-// ---------------------------------------------------------------------------
 
 /// Track lifecycle state for OC-SORT.
 ///
 /// Alias of the shared [`TrackState`].
 pub type OcSortTrackState = TrackState;
 
-// ---------------------------------------------------------------------------
-// Track
-// ---------------------------------------------------------------------------
-
 /// A single tracked object managed by OC-SORT.
-#[derive(Debug, Clone)]
-pub struct OcSortTrack {
-    /// Bounding box in TLWH (top-left x, top-left y, width, height) format.
-    pub tlwh: [f32; 4],
-    /// Detection confidence of the most recent match.
-    pub score: f32,
-    /// Class label of the most recent match.
-    pub class_id: i64,
-    /// Unique monotonically increasing track identifier.
-    pub track_id: u64,
-    /// Current lifecycle state.
-    pub state: OcSortTrackState,
-    /// Total number of detection matches over the track lifetime.
-    pub hits: usize,
-    /// Consecutive detection matches without interruption (resets to 0 on any missed frame).
-    pub hit_streak: usize,
-    /// Frames elapsed since the last detection match.
-    pub time_since_update: usize,
-    /// Total frames since track creation.
-    pub age: usize,
+///
+/// Alias of the shared observation-centric [`ObsTrack`], which carries the Kalman
+/// state and observation history that OC-SORT's velocity (OCM) and re-update (ORU)
+/// logic operate on.
+pub type OcSortTrack = ObsTrack;
 
-    // Kalman filter state (xyah format: cx, cy, aspect, height + velocities).
-    kalman: KalmanTrack,
-
-    // OC-SORT: circular observation history used for OCV and ORU.
-    // Stored as (xyah, frame_id) in insertion order; capped at `delta_t + 1` entries.
-    observations: Vec<(MeasurementVector, usize)>,
-}
-
-impl OcSortTrack {
-    fn new(
-        tlwh: [f32; 4],
-        score: f32,
-        class_id: i64,
-        track_id: u64,
-        frame_id: usize,
-        kf: &KalmanFilter,
-    ) -> Self {
-        let xyah = tlwh_to_xyah(&tlwh);
-        let kalman = KalmanTrack::initiate(&xyah, kf);
-        let observations = vec![(xyah, frame_id)];
-
-        Self {
-            tlwh,
-            score,
-            class_id,
-            track_id,
-            state: OcSortTrackState::Tentative,
-            hits: 1,
-            hit_streak: 1,
-            time_since_update: 0,
-            age: 1,
-            kalman,
-            observations,
-        }
-    }
-
-    /// Kalman-predict one step forward.
-    ///
-    /// Resets `hit_streak` when the track missed the previous frame, matching the
-    /// reference OC-SORT behaviour where consecutive-hit count is used for confirmation.
-    fn predict(&mut self, kf: &KalmanFilter) {
-        if self.time_since_update > 0 {
-            self.hit_streak = 0;
-        }
-        self.tlwh = self.kalman.predict(kf);
-        self.age += 1;
-        self.time_since_update += 1;
-    }
-
-    /// Standard Kalman update with a new matched detection.
-    fn update_kf(&mut self, xyah: &MeasurementVector, kf: &KalmanFilter) {
-        self.kalman.update(xyah, kf);
-        self.tlwh = xyah_to_tlwh(&self.kalman.mean);
-    }
-
-    /// OCV: compute normalised 2-D velocity direction `[dy, dx]` over the last
-    /// `delta_t` frames.
-    ///
-    /// Returns `None` when fewer than two observations are available.
-    /// The direction vector is normalised to unit length (L2 + 1e-6 epsilon).
-    fn obs_direction(&self, delta_t: usize) -> Option<[f32; 2]> {
-        let n = self.observations.len();
-        if n < 2 {
-            return None;
-        }
-        let anchor_idx = n.saturating_sub(delta_t + 1);
-        let (obs_old, _) = &self.observations[anchor_idx];
-        let (obs_new, _) = &self.observations[n - 1];
-        // xyah[0] = cx, xyah[1] = cy
-        let dy = obs_new[1] - obs_old[1];
-        let dx = obs_new[0] - obs_old[0];
-        let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
-        Some([dy / norm, dx / norm])
-    }
-
-    /// ORU: replay interpolated observations to correct KF drift after re-association.
-    ///
-    /// Linearly interpolates between the last recorded observation and the current
-    /// detection in TLWH space (matching the reference implementation), converts each
-    /// virtual observation to xyah, then replays predict → update through the KF so
-    /// that future predictions start from a corrected state.
-    fn our_re_update(
-        &mut self,
-        current_xyah: &MeasurementVector,
-        current_frame: usize,
-        kf: &KalmanFilter,
-    ) {
-        let n = self.observations.len();
-        if n == 0 {
-            return;
-        }
-        let (last_obs, last_frame) = &self.observations[n - 1];
-        let gap = (current_frame as isize - *last_frame as isize).max(1) as usize;
-
-        if gap <= 1 {
-            return;
-        }
-
-        // Interpolate in TLWH space (reference interpolates in (x,y,w,h), not xyah).
-        let last_tlwh = xyah_to_tlwh(last_obs);
-        let current_tlwh = xyah_to_tlwh(current_xyah);
-
-        let (mut mean, mut covariance) = kf.initiate(last_obs);
-
-        for step in 1..=gap {
-            let t = step as f32 / gap as f32;
-            let virtual_tlwh = [
-                last_tlwh[0] + (current_tlwh[0] - last_tlwh[0]) * t,
-                last_tlwh[1] + (current_tlwh[1] - last_tlwh[1]) * t,
-                last_tlwh[2] + (current_tlwh[2] - last_tlwh[2]) * t,
-                last_tlwh[3] + (current_tlwh[3] - last_tlwh[3]) * t,
-            ];
-            let virtual_xyah = tlwh_to_xyah(&virtual_tlwh);
-            let (pm, pc) = kf.predict(&mean, &covariance);
-            mean = pm;
-            covariance = pc;
-            let (um, uc) = kf.update(&mean, &covariance, &virtual_xyah);
-            mean = um;
-            covariance = uc;
-        }
-
-        self.kalman.mean = mean;
-        self.kalman.covariance = covariance;
-        self.tlwh = xyah_to_tlwh(&self.kalman.mean);
-    }
-
-    /// Record a new observation, keeping the history bounded to `max_obs` entries.
-    fn push_observation(&mut self, xyah: MeasurementVector, frame_id: usize, max_obs: usize) {
-        self.observations.push((xyah, frame_id));
-        if self.observations.len() > max_obs {
-            self.observations.remove(0);
-        }
-    }
-
-    fn mark_deleted(&mut self) {
-        self.state = OcSortTrackState::Deleted;
-    }
-
-    fn is_confirmed(&self) -> bool {
-        self.state == OcSortTrackState::Confirmed
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Internal detection wrapper
-// ---------------------------------------------------------------------------
-
+/// Internal detection wrapper.
 #[derive(Debug, Clone)]
 struct Detection {
     tlwh: [f32; 4],
     score: f32,
     class_id: i64,
 }
-
-// ---------------------------------------------------------------------------
-// Tracker
-// ---------------------------------------------------------------------------
 
 /// OC-SORT tracker.
 ///
@@ -233,7 +61,7 @@ pub struct OcSort {
     delta_t: usize,
     /// Momentum weight applied to the direction-consistency cost bonus.
     inertia: f32,
-    kf: KalmanFilter,
+    kf: crate::utils::kalman::KalmanFilter,
     next_id: u64,
     frame_count: usize,
 }
@@ -262,7 +90,7 @@ impl OcSort {
             iou_threshold,
             delta_t,
             inertia: inertia.clamp(0.0, 1.0),
-            kf: KalmanFilter::default(),
+            kf: crate::utils::kalman::KalmanFilter::default(),
             next_id: 1,
             frame_count: 0,
         }
@@ -294,7 +122,7 @@ impl OcSort {
             track.predict(&self.kf);
         }
 
-        // 2. Match detections to tracks (OCM direction-consistency bonus + second-round re-match).
+        // 2. Match detections to tracks (OCM direction-consistency bonus + round-2 re-match).
         let (matches, unmatched_dets, unmatched_trks) = self.associate(&detections);
 
         // 3. Update matched tracks.
@@ -303,22 +131,13 @@ impl OcSort {
             let xyah = tlwh_to_xyah(&det.tlwh);
             let track = &mut self.tracks[*trk_idx];
 
-            let was_lost = track.time_since_update > 0;
-
             // ORU: correct KF drift if the track was re-found after a gap.
-            if was_lost {
+            if track.time_since_update > 0 {
                 track.our_re_update(&xyah, self.frame_count, &self.kf);
             }
-
             track.update_kf(&xyah, &self.kf);
             track.push_observation(xyah, self.frame_count, self.delta_t + 1);
-
-            track.tlwh = det.tlwh;
-            track.score = det.score;
-            track.class_id = det.class_id;
-            track.hits += 1;
-            track.hit_streak += 1;
-            track.time_since_update = 0;
+            track.record_match(det.tlwh, det.score, det.class_id);
         }
 
         // 4. Initialise new tracks for unmatched detections.
@@ -330,6 +149,7 @@ impl OcSort {
                 det.class_id,
                 self.next_id,
                 self.frame_count,
+                None,
                 &self.kf,
             );
             self.next_id += 1;
@@ -340,7 +160,7 @@ impl OcSort {
         for track in &mut self.tracks {
             // Confirm using hit_streak (consecutive hits), matching the reference behaviour.
             if track.time_since_update == 0 && track.hit_streak >= self.min_hits {
-                track.state = OcSortTrackState::Confirmed;
+                track.state = TrackState::Confirmed;
             }
             if track.time_since_update > self.max_age {
                 track.mark_deleted();
@@ -350,12 +170,12 @@ impl OcSort {
         // Delete unmatched tentative tracks immediately.
         let unmatched_trks_set: HashSet<usize> = unmatched_trks.into_iter().collect();
         for (i, track) in self.tracks.iter_mut().enumerate() {
-            if unmatched_trks_set.contains(&i) && track.state == OcSortTrackState::Tentative {
+            if unmatched_trks_set.contains(&i) && track.state == TrackState::Tentative {
                 track.mark_deleted();
             }
         }
 
-        self.tracks.retain(|t| t.state != OcSortTrackState::Deleted);
+        self.tracks.retain(|t| t.state != TrackState::Deleted);
 
         // 6. Return confirmed tracks matched this frame.
         self.tracks
@@ -367,14 +187,10 @@ impl OcSort {
 
     /// Associate detections with tracks.
     ///
-    /// Round 1 IoU on KF-predicted boxes plus an OCM direction-consistency bonus:
-    /// for each (track, detection) pair where the track has a stored velocity direction,
-    /// a bonus proportional to `cos_similarity * inertia * det_score` is added to the
-    /// IoU value before assignment.
-    ///
-    /// Round 2 for still-unmatched pairs, a second IoU pass is run using each
-    /// track's last *observed* position (not the KF prediction), matching the reference
-    /// OC-SORT second-round re-matching step.
+    /// Round 1 is IoU on the KF-predicted boxes plus an OCM direction-consistency
+    /// bonus; round 2 rematches leftovers on each track's last observed position.
+    /// Returns matches as `(detection, track)` pairs plus the unmatched detections
+    /// and tracks.
     fn associate(&self, detections: &[Detection]) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
         let n_trks = self.tracks.len();
         let n_dets = detections.len();
@@ -386,48 +202,20 @@ impl OcSort {
             return (Vec::new(), Vec::new(), (0..n_trks).collect());
         }
 
-        // IoU matrix: rows = tracks, cols = detections.
         let pred_boxes: Vec<[f32; 4]> = self.tracks.iter().map(|t| t.tlwh).collect();
         let det_boxes: Vec<[f32; 4]> = detections.iter().map(|d| d.tlwh).collect();
-        let ious = crate::utils::geometry::iou_batch(&pred_boxes, &det_boxes);
+        let det_scores: Vec<f32> = detections.iter().map(|d| d.score).collect();
 
-        // OCM direction-consistency cost: angle bonus added to IoU before assignment.
-        // For track i and detection j:
-        //   candidate_dir = normalised vector from track's last observation to detection centre
-        //   cos_sim       = dot(stored_velocity_dir, candidate_dir)
-        //   bonus         = (pi/2 - |arccos(cos_sim)|) / pi * inertia * det_score
-        let mut angle_diff: Vec<Vec<f32>> = vec![vec![0.0_f32; n_dets]; n_trks];
+        let ious = iou_batch(&pred_boxes, &det_boxes);
+        let angle_diff = ocm_angle_bonus(
+            &self.tracks,
+            &det_boxes,
+            &det_scores,
+            self.delta_t,
+            self.inertia,
+        );
 
-        for (i, track) in self.tracks.iter().enumerate() {
-            let vel_dir = match track.obs_direction(self.delta_t) {
-                Some(v) => v,
-                None => continue,
-            };
-
-            let (last_xyah, _) = track
-                .observations
-                .last()
-                .expect("observations is non-empty by invariant");
-            let last_cx = last_xyah[0];
-            let last_cy = last_xyah[1];
-
-            for (j, det) in detections.iter().enumerate() {
-                let det_cx = det.tlwh[0] + det.tlwh[2] / 2.0;
-                let det_cy = det.tlwh[1] + det.tlwh[3] / 2.0;
-                let dy = det_cy - last_cy;
-                let dx = det_cx - last_cx;
-                let norm = (dy * dy + dx * dx).sqrt() + 1e-6;
-                let cand_dy = dy / norm;
-                let cand_dx = dx / norm;
-
-                let dot = (vel_dir[0] * cand_dy + vel_dir[1] * cand_dx).clamp(-1.0, 1.0);
-                let angle = dot.acos();
-                let normalized = (std::f32::consts::FRAC_PI_2 - angle.abs()) / std::f32::consts::PI;
-                angle_diff[i][j] = (normalized * self.inertia * det.score).max(0.0);
-            }
-        }
-
-        // Build combined cost matrix and run round-1 assignment.
+        // Round 1: IoU plus the OCM bonus.
         let cost_matrix: Vec<Vec<f32>> = (0..n_trks)
             .map(|i| {
                 (0..n_dets)
@@ -436,50 +224,22 @@ impl OcSort {
             })
             .collect();
 
-        let (mut matches, mut unmatched_dets, mut unmatched_trks) =
+        let (matches_raw, mut unmatched_trks, mut unmatched_dets) =
             greedy_match(&cost_matrix, 1.0 - self.iou_threshold);
+        let mut matches: Vec<(usize, usize)> = matches_raw
+            .into_iter()
+            .map(|(trk, det)| (det, trk))
+            .collect();
 
-        // Round 2: re-match using last observed positions for tracks not matched in round 1.
-        if !unmatched_dets.is_empty() && !unmatched_trks.is_empty() {
-            let left_det_boxes: Vec<[f32; 4]> = unmatched_dets
-                .iter()
-                .map(|&di| detections[di].tlwh)
-                .collect();
-            let left_trk_obs: Vec<[f32; 4]> = unmatched_trks
-                .iter()
-                .map(|&ti| {
-                    xyah_to_tlwh(
-                        &self.tracks[ti]
-                            .observations
-                            .last()
-                            .expect("observations is non-empty by invariant")
-                            .0,
-                    )
-                })
-                .collect();
-
-            let iou_left = crate::utils::geometry::iou_batch(&left_trk_obs, &left_det_boxes);
-
-            let max_iou = iou_left
-                .iter()
-                .flat_map(|r| r.iter())
-                .cloned()
-                .fold(f32::NEG_INFINITY, f32::max);
-
-            if max_iou > self.iou_threshold {
-                let cost_left: Vec<Vec<f32>> = iou_left
-                    .iter()
-                    .map(|row| row.iter().map(|&v| 1.0 - v).collect())
-                    .collect();
-                let (r2_matches, r2_ud, r2_ut) = greedy_match(&cost_left, 1.0 - self.iou_threshold);
-
-                for (det_local, trk_local) in r2_matches {
-                    matches.push((unmatched_dets[det_local], unmatched_trks[trk_local]));
-                }
-                unmatched_dets = r2_ud.into_iter().map(|di| unmatched_dets[di]).collect();
-                unmatched_trks = r2_ut.into_iter().map(|ti| unmatched_trks[ti]).collect();
-            }
-        }
+        // Round 2: rematch leftovers on last observed positions.
+        last_observation_rematch(
+            &self.tracks,
+            &det_boxes,
+            &mut matches,
+            &mut unmatched_dets,
+            &mut unmatched_trks,
+            self.iou_threshold,
+        );
 
         (matches, unmatched_dets, unmatched_trks)
     }
@@ -500,32 +260,11 @@ impl crate::traits::Tracker for OcSort {
 }
 
 // ---------------------------------------------------------------------------
-// Greedy matching
-// ---------------------------------------------------------------------------
-
-/// Greedy assignment for OC-SORT.
-///
-/// Rows are tracks and columns are detections; returns matches as
-/// `(detection, track)` pairs alongside the unmatched detections and tracks.
-fn greedy_match(
-    cost_matrix: &[Vec<f32>],
-    threshold: f32,
-) -> (Vec<(usize, usize)>, Vec<usize>, Vec<usize>) {
-    let (matches, unmatched_rows, unmatched_cols) =
-        crate::utils::assignment::greedy_match(cost_matrix, threshold);
-    let matches = matches.into_iter().map(|(trk, det)| (det, trk)).collect();
-    (matches, unmatched_cols, unmatched_rows)
-}
-
-// ---------------------------------------------------------------------------
 // Python bindings
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
-
-#[cfg(feature = "python")]
-type PyTrackingResult = (u64, [f32; 4], f32, i64);
 
 /// Python-exposed OC-SORT tracker.
 #[cfg(feature = "python")]
@@ -566,7 +305,10 @@ impl PyOcSort {
     ///
     /// Returns:
     ///     list: Confirmed tracks as (track_id, [x, y, w, h], score, class_id) tuples.
-    fn update(&mut self, detections: Vec<([f32; 4], f32, i64)>) -> PyResult<Vec<PyTrackingResult>> {
+    fn update(
+        &mut self,
+        detections: Vec<([f32; 4], f32, i64)>,
+    ) -> PyResult<Vec<crate::trackers::common::PyTrackingResult>> {
         let tracks = self.inner.update(detections);
         Ok(tracks
             .into_iter()
@@ -575,13 +317,10 @@ impl PyOcSort {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::kalman::KalmanFilter;
 
     fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
         ([x, y, w, h], s, 0)
@@ -647,7 +386,7 @@ mod tests {
         ]);
 
         assert_eq!(tracks.len(), 2);
-        let ids: std::collections::HashSet<u64> = tracks.iter().map(|t| t.track_id).collect();
+        let ids: HashSet<u64> = tracks.iter().map(|t| t.track_id).collect();
         assert_eq!(ids.len(), 2);
     }
 
@@ -670,30 +409,25 @@ mod tests {
     fn test_ocsort_ocv_velocity_computed() {
         let kf = KalmanFilter::default();
         let tlwh = [100.0_f32, 100.0, 50.0, 100.0];
-        // cx=125, cy=150
-        let mut track = OcSortTrack::new(tlwh, 0.9, 0, 1, 1, &kf);
+        let mut track = OcSortTrack::new(tlwh, 0.9, 0, 1, 1, None, &kf);
 
         // Single observation: no direction yet.
         assert!(track.obs_direction(3).is_none());
 
         // Add a second observation: object moved 10px to the right.
         let tlwh2 = [110.0_f32, 100.0, 50.0, 100.0];
-        // cx2=135, cy2=150 → dx=10, dy=0 → direction=[0.0, 1.0]
-        let xyah2 = tlwh_to_xyah(&tlwh2);
-        track.push_observation(xyah2, 2, 4);
+        track.push_observation(tlwh_to_xyah(&tlwh2), 2, 4);
 
-        let dir = track.obs_direction(3);
-        assert!(dir.is_some());
-        let d = dir.unwrap();
+        let dir = track.obs_direction(3).unwrap();
         assert!(
-            d[0].abs() < 0.01,
+            dir[0].abs() < 0.01,
             "Expected dy direction ~0.0, got {}",
-            d[0]
+            dir[0]
         );
         assert!(
-            (d[1] - 1.0).abs() < 0.01,
+            (dir[1] - 1.0).abs() < 0.01,
             "Expected dx direction ~1.0, got {}",
-            d[1]
+            dir[1]
         );
     }
 
@@ -701,18 +435,13 @@ mod tests {
     fn test_ocsort_our_does_not_panic_on_re_association() {
         let kf = KalmanFilter::default();
         let tlwh = [100.0_f32, 100.0, 50.0, 100.0];
-        let mut track = OcSortTrack::new(tlwh, 0.9, 0, 1, 1, &kf);
+        let mut track = OcSortTrack::new(tlwh, 0.9, 0, 1, 1, None, &kf);
 
-        // Simulate 5 frames of predict (no observations).
         for _ in 0..5 {
             track.predict(&kf);
         }
 
-        // Re-associate at frame 7.
-        let xyah_new = tlwh_to_xyah(&[130.0_f32, 100.0, 50.0, 100.0]);
-        track.our_re_update(&xyah_new, 7, &kf);
-
-        // Check tlwh is finite.
+        track.our_re_update(&tlwh_to_xyah(&[130.0_f32, 100.0, 50.0, 100.0]), 7, &kf);
         assert!(track.tlwh.iter().all(|v| v.is_finite()));
     }
 
@@ -743,13 +472,9 @@ mod tests {
     fn test_ocsort_hit_streak_resets_on_miss() {
         let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
 
-        // Frame 1: confirm track (min_hits=1).
         tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
-
-        // Frame 2: no detection — track predicts, hit_streak should reset.
         tracker.update(vec![]);
 
-        // Frame 3: detection re-appears; hit_streak restarts from 1.
         let tracks = tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
         assert_eq!(tracks.len(), 1);
         assert_eq!(tracks[0].hit_streak, 1);
@@ -761,15 +486,12 @@ mod tests {
         // Round-2 matching (using last observed position) should recover it.
         let mut tracker = OcSort::new(5, 1, 0.3, 3, 0.2);
 
-        // Establish a confirmed track.
         for _ in 0..2 {
             tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
         }
 
-        // One frame gap.
         tracker.update(vec![]);
 
-        // Reappear at same location — should re-match via round-2 (last observed pos).
         let tracks = tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
         assert_eq!(tracks.len(), 1, "Track should be re-matched after gap");
         assert_eq!(tracks[0].track_id, 1, "Should be the same track");
@@ -777,29 +499,22 @@ mod tests {
 
     #[test]
     fn test_ocsort_ocm_direction_bonus_path() {
-        // After two consecutive matches the track has 2 observations, so
-        // obs_direction() returns Some.  On frame 3 associate() runs with
-        // that track → the angle-diff block at line ~441 is entered and
-        // observations.last() at line ~450 is reached.
+        // Two consecutive matches give the track a direction, so associate() enters
+        // the OCM angle-bonus path on the third frame.
         let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
-        tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]); // obs 1
-        tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]); // obs 2 → Some direction
+        tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
+        tracker.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)]);
         let tracks = tracker.update(vec![det(105.0, 100.0, 50.0, 100.0, 0.9)]);
         assert_eq!(tracks.len(), 1);
     }
 
     #[test]
     fn test_ocsort_round2_observations_last_reached() {
-        // Build a track with 2 observations at position A.  On the next frame
-        // supply a detection at a distant position B (IoU = 0 with A).  Round-1
-        // leaves both unmatched, so the round-2 block (lines ~484-521) is entered
-        // and observations.last() at line ~495 is called for the unmatched track.
+        // Build a track with 2 observations, then supply a distant detection so
+        // round 1 leaves it unmatched and the round-2 last-observation path runs.
         let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
-        tracker.update(vec![det(0.0, 0.0, 50.0, 100.0, 0.9)]); // obs 1 at A
-        tracker.update(vec![det(0.0, 0.0, 50.0, 100.0, 0.9)]); // obs 2 at A
-        // Detection far from A: track is unmatched in round 1 → round-2 block entered.
+        tracker.update(vec![det(0.0, 0.0, 50.0, 100.0, 0.9)]);
+        tracker.update(vec![det(0.0, 0.0, 50.0, 100.0, 0.9)]);
         tracker.update(vec![det(10000.0, 0.0, 50.0, 100.0, 0.9)]);
-        // Track at A is now age-1 unmatched; new track created at B.
-        // Just verify no panic — coverage of line ~495 is the goal.
     }
 }


### PR DESCRIPTION
OC-SORT and Deep OC-SORT were near-copies: the same track type (Kalman state plus an observation history) and the same two association steps, with Deep OC-SORT adding an appearance term on top.

- `common::ObsTrack` is the one observation-centric track both use. It holds the Kalman state, the observation history that drives velocity direction (OCM) and re-update on re-association (ORU), and the appearance-embedding buffer Deep OC-SORT flushes into its gallery (OC-SORT leaves it empty). `OcSortTrack` and `DeepOcSortTrack` are now aliases of it, so the public fields (`track_id`, `tlwh`, `score`, `class_id`) stay the same.
- `common::association` holds the OCM direction bonus and the round-2 rematch on last observed positions. Each tracker keeps only its own round-1 cost blend (OC-SORT is motion only; Deep OC-SORT mixes in the gated appearance cost).
- The repeated Python result tuple is now `common::PyTrackingResult`.
- ByteTrack cleanup: removed a dead `detections_second` buffer and the stale thinking-out-loud comments in `update()` and the tests.