### PR TITLE
feat(botsort): add BoT-SORT tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@
 | [DeepSORT](https://arxiv.org/abs/1703.07402)     | IoU + cosine distance             | Yes (pluggable)    |
 | [OC-SORT](https://arxiv.org/abs/2203.14360)      | IoU + velocity direction (OCM)    | No                 |
 | [Deep OC-SORT](https://arxiv.org/abs/2302.11813) | IoU + velocity (OCM) + appearance | Yes (pluggable)    |
+| [BoT-SORT](https://arxiv.org/abs/2206.14651)     | IoU + appearance + camera motion  | Yes (pluggable)    |
 | [SORT](https://arxiv.org/abs/1602.00763)         | IoU + Kalman filter               | No                 |
 
 ## Features
 
 - 🚀 **Native Rust Core** Blazingly fast tracking (< 1ms/frame for ByteTrack) with full memory safety
 - 🐍 **Python Bindings** First-class `pip install trackforge` support via PyO3
-- 🎯 **Multi-Algorithm** ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, and SORT with a unified API
+- 🎯 **Multi-Algorithm** ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, BoT-SORT, and SORT with a unified API
 - 🔌 **Pluggable Re-ID** DeepSORT's appearance extractor is a trait; plug in any feature model
 - 📐 **Generic Kalman Filter** Configurable position/velocity weighting, gating distance computation
 
@@ -164,6 +165,34 @@ for track_id, tlwh, score, class_id in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 
+### Python - BoT-SORT
+
+```python
+from trackforge import BOTSORT
+
+tracker = BOTSORT(
+    track_thresh=0.5,
+    track_buffer=30,
+    match_thresh=0.8,
+    det_thresh=0.6,
+    proximity_thresh=0.5,
+    appearance_thresh=0.25,
+)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
+
+# Pass embeddings for appearance-aware tracking, or omit them for motion only.
+tracks = tracker.update(detections, embeddings)
+
+# Moving camera: pass a [a, b, tx, c, d, ty] affine mapping the previous frame
+# to the current one.
+tracks = tracker.update(detections, embeddings, [1.0, 0.0, 12.0, 0.0, 1.0, -4.0])
+
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
 ### Rust - ByteTrack
 
 ```rust
@@ -234,6 +263,22 @@ for t in tracks {
 }
 ```
 
+### Rust - BoT-SORT
+
+```rust
+use trackforge::trackers::botsort::BotSort;
+
+let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+let detections = vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)];
+let embeddings = vec![vec![0.1, 0.2, 0.3]]; // one appearance vector per detection
+let tracks = tracker.update(detections, &embeddings);
+
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
 ### Rust - SORT
 
 ```rust
@@ -259,6 +304,7 @@ Runnable demos live under [`examples/`](examples/), with both a Python and a Rus
 | DeepSORT     | [`deepsort_demo.py`](examples/python/deepsort_demo.py) (YOLO + ResNet18)                                                                | [`deepsort_simple.rs`](examples/deepsort_simple.rs), [`deepsort_ort.rs`](examples/deepsort_ort.rs) (ONNX) |
 | OC-SORT      | [`ocsort_demo.py`](examples/python/ocsort_demo.py)                                                                                      | —                                                                                                         |
 | Deep OC-SORT | [`deep_ocsort_demo.py`](examples/python/deep_ocsort_demo.py) (YOLO + ResNet18)                                                          | —                                                                                                         |
+| BoT-SORT     | [`botsort_demo.py`](examples/python/botsort_demo.py) (YOLO + ResNet18)                                                                  | —                                                                                                         |
 | SORT         | [`sort_yolo_demo.py`](examples/python/sort_yolo_demo.py) (YOLO), [`sort_rtdetr_demo.py`](examples/python/sort_rtdetr_demo.py) (RT-DETR) | —                                                                                                         |
 | Comparison   | [`tracker_comparison.py`](examples/python/tracker_comparison.py) (ByteTrack vs SORT side-by-side)                                       | —                                                                                                         |
 
@@ -405,6 +451,13 @@ also cite the paper for the tracker you use:
   author={Maggiolino, Gerard and Ahmad, Adnan and Cao, Jinkun and Kitani, Kris},
   booktitle={IEEE International Conference on Image Processing (ICIP)},
   year={2023}
+}
+
+@article{aharon2022botsort,
+  title={BoT-SORT: Robust Associations Multi-Pedestrian Tracking},
+  author={Aharon, Nir and Orfaig, Roy and Bobrovsky, Ben-Zion},
+  journal={arXiv preprint arXiv:2206.14651},
+  year={2022}
 }
 ```
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,5 +9,6 @@
   - [OC-SORT](./trackers/ocsort.md)
   - [DeepSORT](./trackers/deepsort.md)
   - [Deep OC-SORT](./trackers/deep_ocsort.md)
+  - [BoT-SORT](./trackers/botsort.md)
 - [Parameters](./parameters.md)
 - [Examples](./examples.md)

--- a/book/src/trackers/botsort.md
+++ b/book/src/trackers/botsort.md
@@ -1,0 +1,57 @@
+# BoT-SORT
+
+**BoT-SORT** ([arXiv 2206.14651](https://arxiv.org/abs/2206.14651)). Extends ByteTrack's two-stage
+cascade with two additions:
+
+- **Camera motion compensation** warps each track's Kalman prediction by a caller-supplied affine
+  transform before association, so tracking survives panning and zooming cameras.
+- **Appearance fusion** combines a cosine distance to each track's appearance embedding with the IoU
+  distance in the high-confidence stage. Appearance is used only when it is confident (below
+  `appearance_thresh`) and the pair is spatially close (IoU distance below `proximity_thresh`); the
+  fused cost is the smaller of the two. Each track keeps an exponential moving average of its
+  embeddings.
+
+With no embeddings the association reduces to ByteTrack with camera motion, so appearance is a strict
+add-on. This is a clean-room implementation. CMC is applied from a transform you supply (for example
+estimated with OpenCV); the tracker does not estimate camera motion itself. Pass the affine as
+`[a, b, tx, c, d, ty]` to `update`.
+
+```python
+from trackforge import BOTSORT
+
+tracker = BOTSORT(track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6,
+                  proximity_thresh=0.5, appearance_thresh=0.25)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection; omit for motion only
+tracks = tracker.update(detections, embeddings)
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
+## Parameters
+
+| Parameter           | Default | Description                                             |
+| ------------------- | ------- | ------------------------------------------------------- |
+| `track_thresh`      | 0.5     | Confidence split between high- and low-score detections |
+| `track_buffer`      | 30      | Frames a lost track is kept alive before removal        |
+| `match_thresh`      | 0.8     | Maximum cost for a first-stage (high-confidence) match  |
+| `det_thresh`        | 0.6     | Minimum score to start a new track                      |
+| `proximity_thresh`  | 0.5     | IoU-distance gate above which appearance is ignored     |
+| `appearance_thresh` | 0.25    | Cosine-distance gate above which appearance is ignored  |
+
+**Tuning:** supply a camera-motion affine on moving-camera footage; leave it out for a static camera.
+Provide embeddings when a Re-ID model is available and identities matter, and tighten
+`appearance_thresh` to only trust strong appearance matches. The two-stage thresholds behave as in
+ByteTrack.
+
+## Citation
+
+```bibtex
+@article{aharon2022botsort,
+  title={BoT-SORT: Robust Associations Multi-Pedestrian Tracking},
+  author={Aharon, Nir and Orfaig, Roy and Bobrovsky, Ben-Zion},
+  journal={arXiv preprint arXiv:2206.14651},
+  year={2022}
+}
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,7 @@
 - [OC-SORT](https://arxiv.org/abs/2203.14360)
 - [DeepSORT](https://arxiv.org/abs/1703.07402)
 - [Deep OC-SORT](https://arxiv.org/abs/2302.11813)
+- [BoT-SORT](https://arxiv.org/abs/2206.14651)
 - Python bindings and PyPI package
 - Rust and Python examples
 
@@ -19,7 +20,6 @@ most of the work is the association logic specific to each method.
 
 | Tracker      | Builds on                               | Paper                                          | Reference                                                     |
 | ------------ | --------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
-| BoT-SORT     | ByteTrack + Re-ID + camera motion       | [2206.14651](https://arxiv.org/abs/2206.14651) | [NirAharon/BoT-SORT](https://github.com/NirAharon/BoT-SORT)   |
 | StrongSORT   | DeepSORT + stronger Re-ID               | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)   |
 | StrongSORT++ | StrongSORT + camera motion (AFLink/GSI) | [2202.13514](https://arxiv.org/abs/2202.13514) | [dyhBUPT/StrongSORT](https://github.com/dyhBUPT/StrongSORT)   |
 | TrackTrack   | Track-centric online association        | [CVPR 2025](https://arxiv.org/abs/2504.20083)  | [kamkyu94/TrackTrack](https://github.com/kamkyu94/TrackTrack) |

--- a/examples/python/botsort_demo.py
+++ b/examples/python/botsort_demo.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""BoT-SORT tracking demo with YOLO detection and ResNet18 appearance features.
+
+BoT-SORT extends ByteTrack with camera motion compensation and an appearance-fused
+association. Pass ``--no-reid`` to track on motion alone.
+
+Requirements:
+    pip install ultralytics opencv-python trackforge torch torchvision pillow
+
+Example:
+    $ python botsort_demo.py --video people.mp4 --model yolo11n.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+from ultralytics import YOLO
+
+import trackforge
+from common import (
+    create_video_writer,
+    draw_hud,
+    draw_track,
+    label_for,
+    load_video,
+    log_progress,
+    yolo_detections,
+)
+
+
+def run_tracking(video: str, output: str, model_path: str, use_reid: bool) -> None:
+    """Run BoT-SORT over a video and write an annotated copy.
+
+    Args:
+        video: Path to the input video.
+        output: Path for the annotated output video.
+        model_path: Path to the YOLO model weights.
+        use_reid: When True, extract ResNet18 embeddings for appearance fusion;
+            when False, track on motion alone.
+    """
+    model = YOLO(model_path)
+    tracker = trackforge.BOTSORT(
+        track_thresh=0.5,
+        track_buffer=30,
+        match_thresh=0.8,
+        det_thresh=0.6,
+        proximity_thresh=0.5,
+        appearance_thresh=0.25,
+    )
+
+    embedder = transform = None
+    if use_reid:
+        from reid import extract_features, get_embedder
+
+        embedder, transform = get_embedder()
+
+    cap, info = load_video(video)
+    writer = create_video_writer(output, info)
+    print(
+        f"video: {info.width}x{info.height} @ {info.fps}fps, {info.total_frames} frames"
+    )
+
+    frame_count = 0
+    start = time.time()
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        frame_count += 1
+
+        detections = yolo_detections(model, frame, classes=[0])
+        if use_reid:
+            embeddings = extract_features(
+                embedder, transform, frame, [d[0] for d in detections]
+            )
+        else:
+            embeddings = []
+        tracks = tracker.update(detections, embeddings)
+        for track_id, tlwh, score, class_id in tracks:
+            draw_track(
+                frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
+            )
+
+        draw_hud(
+            frame,
+            f"BoT-SORT | frame {frame_count}/{info.total_frames} | tracks {len(tracks)}",
+        )
+        writer.write(frame)
+        log_progress(frame_count, info.total_frames, start)
+
+    cap.release()
+    writer.release()
+    print(f"done: {frame_count} frames -> {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="BoT-SORT tracking with YOLO detection and ResNet18 embeddings."
+    )
+    parser.add_argument("--video", default="people.mp4", help="input video path")
+    parser.add_argument(
+        "--output", default="output_botsort.mp4", help="output video path"
+    )
+    parser.add_argument("--model", default="yolo11n.pt", help="YOLO model weights")
+    parser.add_argument(
+        "--no-reid", action="store_true", help="track on motion alone (skip embeddings)"
+    )
+    args = parser.parse_args()
+
+    if not Path(args.video).exists():
+        print(f"video not found: {args.video}")
+        return
+    run_tracking(args.video, args.output, args.model, use_reid=not args.no_reid)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/trackforge.pyi
+++ b/python/trackforge.pyi
@@ -1,6 +1,6 @@
 from typing import List, Optional, Tuple
 
-__all__ = ["BYTETRACK", "SORT", "OCSORT", "DEEPSORT", "DEEPOCSORT"]
+__all__ = ["BYTETRACK", "SORT", "OCSORT", "DEEPSORT", "DEEPOCSORT", "BOTSORT"]
 
 class BYTETRACK:
     """
@@ -198,6 +198,55 @@ class DEEPOCSORT:
         appearance_weight: float = 0.5,
         max_cosine_distance: float = 0.2,
         nn_budget: int = 100,
+    ) -> None: ...
+    def update(
+        self,
+        detections: List[Tuple[List[float], float, int]],
+        embeddings: List[List[float]] = ...,
+        camera_motion: Optional[List[float]] = ...,
+    ) -> List[Tuple[int, List[float], float, int]]: ...
+
+class BOTSORT:
+    """
+    BoT-SORT tracker: ByteTrack with camera motion and appearance fusion.
+
+    Adds camera motion compensation and an appearance-fused first association stage
+    on top of ByteTrack's two-stage cascade. Pass embeddings for appearance-aware
+    tracking, or omit them to track on motion only.
+
+    **Usage Example:**
+
+    ```python
+    from trackforge import BOTSORT
+
+    tracker = BOTSORT(
+        track_thresh=0.5,
+        track_buffer=30,
+        match_thresh=0.8,
+        det_thresh=0.6,
+        proximity_thresh=0.5,
+        appearance_thresh=0.25,
+    )
+
+    detections = [
+        ([100.0, 100.0, 50.0, 100.0], 0.9, 0),
+    ]
+    embeddings = [[0.1, 0.2, 0.3]]
+
+    tracks = tracker.update(detections, embeddings)
+    for track_id, box, score, class_id in tracks:
+        print(f"Track ID: {track_id}, Box: {box}")
+    ```
+    """
+
+    def __init__(
+        self,
+        track_thresh: float = 0.5,
+        track_buffer: int = 30,
+        match_thresh: float = 0.8,
+        det_thresh: float = 0.6,
+        proximity_thresh: float = 0.5,
+        appearance_thresh: float = 0.25,
     ) -> None: ...
     def update(
         self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! | [`ocsort`] | None | IoU + velocity correction | Scenes with frequent occlusions |
 //! | [`deepsort`] | Re-ID embeddings | Appearance + IoU | Long occlusions, dense crowds |
 //! | [`deep_ocsort`] | Re-ID embeddings | IoU + velocity + appearance | Occlusions with re-identification |
+//! | [`botsort`] | Re-ID embeddings | IoU + appearance + camera motion | Moving cameras, dense crowds |
 //!
 //! # SORT
 //!
@@ -157,6 +158,7 @@
 //! [`ocsort`]: trackers::ocsort
 //! [`deepsort`]: trackers::deepsort
 //! [`deep_ocsort`]: trackers::deep_ocsort
+//! [`botsort`]: trackers::botsort
 //! [`AppearanceExtractor`]: traits::AppearanceExtractor
 
 pub mod trackers;
@@ -176,5 +178,6 @@ fn trackforge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<trackers::deepsort::python::PyDeepSort>()?;
     m.add_class::<trackers::ocsort::PyOcSort>()?;
     m.add_class::<trackers::deep_ocsort::python::PyDeepOcSort>()?;
+    m.add_class::<trackers::botsort::PyBotSort>()?;
     Ok(())
 }

--- a/src/trackers/botsort/README.md
+++ b/src/trackers/botsort/README.md
@@ -1,0 +1,106 @@
+# BoT-SORT: Robust associations multi-object tracking
+
+This module implements the BoT-SORT algorithm.
+
+> **BoT-SORT: Robust Associations Multi-Pedestrian Tracking**
+> Nir Aharon, Roy Orfaig, Ben-Zion Bobrovsky
+> [arXiv:2206.14651](https://arxiv.org/abs/2206.14651)
+
+## Algorithm overview
+
+BoT-SORT builds on ByteTrack's two-stage association and adds two pieces:
+
+- **Camera motion compensation (CMC)** warps each track's Kalman prediction by a
+  caller-supplied affine transform before association, so tracking survives panning and
+  zooming cameras. The transform is the shared `common::cmc` infrastructure.
+- **Appearance fusion** combines a cosine distance to each track's appearance embedding
+  with the IoU distance in the high-confidence stage. Appearance is used only when it is
+  confident (below `appearance_thresh`) and the pair is spatially close (IoU distance
+  below `proximity_thresh`); the fused cost is the smaller of the two. Each track keeps
+  an exponential moving average of its embeddings. With no embeddings the association
+  reduces to ByteTrack with camera motion.
+
+The two-stage cascade is unchanged from ByteTrack: high-confidence detections are matched
+first (on the fused cost), then low-confidence detections recover fragmented tracks on
+IoU alone.
+
+This is a clean-room implementation. The tracker applies a camera-motion transform but
+does not estimate it: the caller supplies the affine (for example from image
+registration), keeping the core free of heavy computer-vision dependencies.
+
+## Builds on
+
+- `utils::kalman` - the shared 8-dimensional Kalman filter
+- `utils::geometry` - `iou_batch`, `tlwh_to_xyah`
+- `utils::assignment` - `greedy_match`, `iou_match`
+- `trackers::common` - `KalmanTrack` and `CameraMotion` (CMC)
+- `trackers::byte_track` - the `TrackState` lifecycle shared with ByteTrack
+
+## Parameters
+
+| Parameter           | Default | Description                                                  |
+| ------------------- | ------- | ------------------------------------------------------------ |
+| `track_thresh`      | 0.5     | Confidence split between high- and low-score detections      |
+| `track_buffer`      | 30      | Frames a lost track is kept alive before removal             |
+| `match_thresh`      | 0.8     | Maximum cost for a first-stage (high-confidence) match       |
+| `det_thresh`        | 0.6     | Minimum score to start a new track                           |
+| `proximity_thresh`  | 0.5     | IoU-distance gate above which appearance is ignored          |
+| `appearance_thresh` | 0.25    | Cosine-distance gate above which appearance is ignored       |
+
+## Rust API
+
+```rust,ignore
+use trackforge::trackers::botsort::BotSort;
+
+let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+let detections = vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)];
+let embeddings = vec![vec![0.1, 0.2, 0.3]]; // one appearance vector per detection
+let tracks = tracker.update(detections, &embeddings);
+for t in tracks {
+    println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+}
+```
+
+## Python API
+
+```python
+from trackforge import BOTSORT
+
+tracker = BOTSORT(
+    track_thresh=0.5,
+    track_buffer=30,
+    match_thresh=0.8,
+    det_thresh=0.6,
+    proximity_thresh=0.5,
+    appearance_thresh=0.25,
+)
+
+detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
+embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection; omit for motion only
+tracks = tracker.update(detections, embeddings)
+
+# Moving camera: pass a [a, b, tx, c, d, ty] affine mapping the previous frame
+# to the current one (estimate it however you like, e.g. with OpenCV).
+camera_motion = [1.0, 0.0, 12.0, 0.0, 1.0, -4.0]
+tracks = tracker.update(detections, embeddings, camera_motion)
+
+for track_id, tlwh, score, class_id in tracks:
+    print(f"ID: {track_id}, Box: {tlwh}")
+```
+
+## Credit
+
+Clean-room Rust implementation of the algorithm described in the paper above. Original
+reference implementation: [NirAharon/BoT-SORT](https://github.com/NirAharon/BoT-SORT).
+
+## Citation
+
+```bibtex
+@article{aharon2022botsort,
+  title={BoT-SORT: Robust Associations Multi-Pedestrian Tracking},
+  author={Aharon, Nir and Orfaig, Roy and Bobrovsky, Ben-Zion},
+  journal={arXiv preprint arXiv:2206.14651},
+  year={2022}
+}
+```

--- a/src/trackers/botsort/README.md
+++ b/src/trackers/botsort/README.md
@@ -38,14 +38,14 @@ registration), keeping the core free of heavy computer-vision dependencies.
 
 ## Parameters
 
-| Parameter           | Default | Description                                                  |
-| ------------------- | ------- | ------------------------------------------------------------ |
-| `track_thresh`      | 0.5     | Confidence split between high- and low-score detections      |
-| `track_buffer`      | 30      | Frames a lost track is kept alive before removal             |
-| `match_thresh`      | 0.8     | Maximum cost for a first-stage (high-confidence) match       |
-| `det_thresh`        | 0.6     | Minimum score to start a new track                           |
-| `proximity_thresh`  | 0.5     | IoU-distance gate above which appearance is ignored          |
-| `appearance_thresh` | 0.25    | Cosine-distance gate above which appearance is ignored       |
+| Parameter           | Default | Description                                             |
+| ------------------- | ------- | ------------------------------------------------------- |
+| `track_thresh`      | 0.5     | Confidence split between high- and low-score detections |
+| `track_buffer`      | 30      | Frames a lost track is kept alive before removal        |
+| `match_thresh`      | 0.8     | Maximum cost for a first-stage (high-confidence) match  |
+| `det_thresh`        | 0.6     | Minimum score to start a new track                      |
+| `proximity_thresh`  | 0.5     | IoU-distance gate above which appearance is ignored     |
+| `appearance_thresh` | 0.25    | Cosine-distance gate above which appearance is ignored  |
 
 ## Rust API
 

--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -1,0 +1,718 @@
+#![doc = include_str!("README.md")]
+
+use crate::trackers::byte_track::TrackState;
+use crate::trackers::common::{CameraMotion, KalmanTrack};
+use crate::utils::assignment::{greedy_match, iou_match};
+use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
+use crate::utils::kalman::KalmanFilter;
+
+/// Exponential moving-average weight for the per-track appearance feature.
+const FEATURE_MOMENTUM: f32 = 0.9;
+
+/// L2-normalise a feature vector, returning zeros unchanged.
+fn l2_normalize(feature: &[f32]) -> Vec<f32> {
+    let norm = feature.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if norm <= 1e-12 {
+        return feature.to_vec();
+    }
+    feature.iter().map(|v| v / norm).collect()
+}
+
+/// Cosine distance between two L2-normalised vectors, clamped to `[0, 2]`.
+fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    (1.0 - dot).clamp(0.0, 2.0)
+}
+
+/// A detection with an optional appearance embedding.
+struct Detection {
+    tlwh: [f32; 4],
+    score: f32,
+    class_id: i64,
+    feature: Option<Vec<f32>>,
+}
+
+/// A single tracked object managed by BoT-SORT.
+///
+/// Carries the shared [`KalmanTrack`] state, the ByteTrack-style lifecycle used by
+/// the two-stage cascade, and a smoothed appearance embedding (exponential moving
+/// average) used for the appearance-fused association.
+#[derive(Debug, Clone)]
+pub struct BotTrack {
+    /// Bounding box in TLWH (top-left x, top-left y, width, height) format.
+    pub tlwh: [f32; 4],
+    /// Detection confidence of the most recent match.
+    pub score: f32,
+    /// Class label of the most recent match.
+    pub class_id: i64,
+    /// Unique track identifier (0 until the track is activated).
+    pub track_id: u64,
+    /// Lifecycle state (`New`, `Tracked`, `Lost`, `Removed`).
+    pub state: TrackState,
+    /// Whether the track is confirmed and returned to callers.
+    pub is_activated: bool,
+    /// Frame id of the most recent update.
+    pub frame_id: usize,
+    /// Frame id at which the track started.
+    pub start_frame: usize,
+    /// Number of consecutive frames the track has been followed.
+    pub tracklet_len: usize,
+
+    kalman: KalmanTrack,
+    smooth_feat: Option<Vec<f32>>,
+}
+
+impl BotTrack {
+    /// Build an unactivated track from a detection (Kalman state seeded from its box).
+    fn from_detection(det: &Detection, kf: &KalmanFilter) -> Self {
+        let kalman = KalmanTrack::initiate(&tlwh_to_xyah(&det.tlwh), kf);
+        Self {
+            tlwh: det.tlwh,
+            score: det.score,
+            class_id: det.class_id,
+            track_id: 0,
+            state: TrackState::New,
+            is_activated: false,
+            frame_id: 0,
+            start_frame: 0,
+            tracklet_len: 0,
+            kalman,
+            smooth_feat: det.feature.as_ref().map(|f| l2_normalize(f)),
+        }
+    }
+
+    /// Confirm a fresh detection as a new track with the given id.
+    fn activate(&mut self, frame_id: usize, track_id: u64) {
+        self.track_id = track_id;
+        self.state = TrackState::Tracked;
+        self.is_activated = true;
+        self.frame_id = frame_id;
+        self.start_frame = frame_id;
+        self.tracklet_len = 0;
+    }
+
+    /// Correct a matched track with a new detection.
+    fn update(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+        self.kalman.update(&tlwh_to_xyah(&det.tlwh), kf);
+        self.tlwh = det.tlwh;
+        self.score = det.score;
+        self.class_id = det.class_id;
+        self.state = TrackState::Tracked;
+        self.is_activated = true;
+        self.frame_id = frame_id;
+        self.tracklet_len += 1;
+        if let Some(f) = &det.feature {
+            self.update_features(f);
+        }
+    }
+
+    /// Bring a lost track back with a matched detection, keeping its id.
+    fn re_activate(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+        self.kalman.update(&tlwh_to_xyah(&det.tlwh), kf);
+        self.tlwh = det.tlwh;
+        self.score = det.score;
+        self.class_id = det.class_id;
+        self.state = TrackState::Tracked;
+        self.is_activated = true;
+        self.frame_id = frame_id;
+        self.tracklet_len = 0;
+        if let Some(f) = &det.feature {
+            self.update_features(f);
+        }
+    }
+
+    /// Kalman-predict one step forward, damping height velocity while not tracked.
+    fn predict(&mut self, kf: &KalmanFilter) {
+        if self.state != TrackState::Tracked {
+            self.kalman.mean[7] = 0.0;
+        }
+        self.tlwh = self.kalman.predict(kf);
+    }
+
+    /// Warp the predicted state by a camera motion transform.
+    fn apply_camera_motion(&mut self, cmc: &CameraMotion) {
+        self.tlwh = self.kalman.apply_camera_motion(cmc);
+    }
+
+    /// Blend a new embedding into the smoothed feature (EMA, then renormalise).
+    fn update_features(&mut self, feature: &[f32]) {
+        let feature = l2_normalize(feature);
+        match &mut self.smooth_feat {
+            None => self.smooth_feat = Some(feature),
+            Some(sf) => {
+                for (s, f) in sf.iter_mut().zip(&feature) {
+                    *s = FEATURE_MOMENTUM * *s + (1.0 - FEATURE_MOMENTUM) * f;
+                }
+                *sf = l2_normalize(sf);
+            }
+        }
+    }
+}
+
+/// BoT-SORT tracker.
+///
+/// Extends ByteTrack's two-stage cascade with camera motion compensation and an
+/// appearance-fused first stage. Camera motion is supplied by the caller as an
+/// affine transform (see [`CameraMotion`]); appearance embeddings are optional and,
+/// when present, fused into the high-confidence association by taking the smaller of
+/// the IoU distance and the gated cosine distance.
+///
+/// ## Example
+///
+/// ```rust
+/// use trackforge::trackers::botsort::BotSort;
+///
+/// // track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6,
+/// // proximity_thresh=0.5, appearance_thresh=0.25
+/// let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+///
+/// let detections = vec![([100.0, 100.0, 50.0, 100.0], 0.9, 0)];
+/// let tracks = tracker.update(detections, &[]);
+/// for t in &tracks {
+///     println!("ID: {}, Box: {:?}", t.track_id, t.tlwh);
+/// }
+/// ```
+pub struct BotSort {
+    tracked_stracks: Vec<BotTrack>,
+    lost_stracks: Vec<BotTrack>,
+    frame_id: usize,
+    buffer_size: usize,
+    track_thresh: f32,
+    match_thresh: f32,
+    det_thresh: f32,
+    proximity_thresh: f32,
+    appearance_thresh: f32,
+    kalman_filter: KalmanFilter,
+    next_id: u64,
+}
+
+impl BotSort {
+    /// Create a new BoT-SORT tracker.
+    ///
+    /// # Arguments
+    ///
+    /// * `track_thresh` - Confidence split between high- and low-score detections (default: 0.5).
+    /// * `track_buffer` - Frames a lost track is kept alive (default: 30).
+    /// * `match_thresh` - Maximum cost for a first-stage match (default: 0.8).
+    /// * `det_thresh` - Minimum score to start a new track (default: 0.6).
+    /// * `proximity_thresh` - IoU-distance gate above which appearance is ignored (default: 0.5).
+    /// * `appearance_thresh` - Cosine-distance gate above which appearance is ignored (default: 0.25).
+    pub fn new(
+        track_thresh: f32,
+        track_buffer: usize,
+        match_thresh: f32,
+        det_thresh: f32,
+        proximity_thresh: f32,
+        appearance_thresh: f32,
+    ) -> Self {
+        Self {
+            tracked_stracks: Vec::new(),
+            lost_stracks: Vec::new(),
+            frame_id: 0,
+            buffer_size: track_buffer,
+            track_thresh,
+            match_thresh,
+            det_thresh,
+            proximity_thresh,
+            appearance_thresh,
+            kalman_filter: KalmanFilter::default(),
+            next_id: 1,
+        }
+    }
+
+    /// Update the tracker with the current frame's detections and embeddings.
+    ///
+    /// `embeddings` is parallel to `detections`; pass an empty slice to track on
+    /// motion only. Returns the activated tracks for this frame.
+    pub fn update(
+        &mut self,
+        detections: Vec<([f32; 4], f32, i64)>,
+        embeddings: &[Vec<f32>],
+    ) -> Vec<BotTrack> {
+        self.update_with_camera_motion(detections, embeddings, &CameraMotion::identity())
+    }
+
+    /// Update the tracker, first warping track predictions by `camera_motion`.
+    ///
+    /// `camera_motion` maps the previous frame's coordinates into the current frame
+    /// (see [`CameraMotion`]); pass [`CameraMotion::identity`] for a static camera.
+    pub fn update_with_camera_motion(
+        &mut self,
+        detections: Vec<([f32; 4], f32, i64)>,
+        embeddings: &[Vec<f32>],
+        camera_motion: &CameraMotion,
+    ) -> Vec<BotTrack> {
+        self.frame_id += 1;
+
+        let use_reid = !embeddings.is_empty() && embeddings.len() == detections.len();
+
+        // Split detections into high- and low-confidence sets, carrying embeddings.
+        let mut dets_high: Vec<Detection> = Vec::new();
+        let mut dets_low: Vec<Detection> = Vec::new();
+        for (i, (tlwh, score, class_id)) in detections.into_iter().enumerate() {
+            let feature = if use_reid {
+                Some(embeddings[i].clone())
+            } else {
+                None
+            };
+            let det = Detection {
+                tlwh,
+                score,
+                class_id,
+                feature,
+            };
+            if det.score >= self.track_thresh {
+                dets_high.push(det);
+            } else {
+                dets_low.push(det);
+            }
+        }
+
+        // Predict, then warp by camera motion.
+        let warp = !camera_motion.is_identity();
+        for track in self
+            .tracked_stracks
+            .iter_mut()
+            .chain(&mut self.lost_stracks)
+        {
+            track.predict(&self.kalman_filter);
+            if warp {
+                track.apply_camera_motion(camera_motion);
+            }
+        }
+
+        // First stage: high-confidence detections against tracked + lost tracks,
+        // matched on the appearance-fused cost. Tracks are activated on creation, so
+        // pool[0..n_tracked] are the tracked tracks and the rest are lost.
+        let mut tracked: Vec<BotTrack> = self.tracked_stracks.drain(..).collect();
+        let n_tracked = tracked.len();
+        let mut pool: Vec<BotTrack> = Vec::new();
+        pool.append(&mut tracked);
+        pool.append(&mut self.lost_stracks);
+
+        let mut activated: Vec<BotTrack> = Vec::new();
+        let mut refind: Vec<BotTrack> = Vec::new();
+        let mut lost: Vec<BotTrack> = Vec::new();
+
+        // Guard the empty case: greedy_match on an empty matrix cannot report the
+        // unmatched detections, so a first frame (no tracks) would drop them.
+        let (matches, u_track, u_det_high) = if pool.is_empty() || dets_high.is_empty() {
+            (
+                Vec::new(),
+                (0..pool.len()).collect::<Vec<_>>(),
+                (0..dets_high.len()).collect::<Vec<_>>(),
+            )
+        } else {
+            let cost = self.fused_cost(&pool, &dets_high, use_reid);
+            greedy_match(&cost, self.match_thresh)
+        };
+
+        for (itrack, idet) in matches {
+            let det = &dets_high[idet];
+            if pool[itrack].state == TrackState::Tracked {
+                pool[itrack].update(det, self.frame_id, &self.kalman_filter);
+                activated.push(pool[itrack].clone());
+            } else {
+                pool[itrack].re_activate(det, self.frame_id, &self.kalman_filter);
+                refind.push(pool[itrack].clone());
+            }
+        }
+
+        // Second stage: low-confidence detections against still-Tracked leftovers,
+        // matched on IoU only.
+        let r_tracked: Vec<usize> = u_track
+            .iter()
+            .copied()
+            .filter(|&i| pool[i].state == TrackState::Tracked)
+            .collect();
+        let r_boxes: Vec<[f32; 4]> = r_tracked.iter().map(|&i| pool[i].tlwh).collect();
+        let low_boxes: Vec<[f32; 4]> = dets_low.iter().map(|d| d.tlwh).collect();
+        let (matches_low, u_track_low, _) = iou_match(&r_boxes, &low_boxes, 0.5);
+
+        // `r_tracked` only holds Tracked-state tracks, so a second-stage match is
+        // always a plain update (never a re-activation).
+        for (local, idet) in matches_low {
+            let itrack = r_tracked[local];
+            let det = &dets_low[idet];
+            pool[itrack].update(det, self.frame_id, &self.kalman_filter);
+            activated.push(pool[itrack].clone());
+        }
+
+        // Tracked leftovers from the second stage become Lost.
+        for &local in &u_track_low {
+            let itrack = r_tracked[local];
+            if pool[itrack].state != TrackState::Lost {
+                pool[itrack].state = TrackState::Lost;
+                lost.push(pool[itrack].clone());
+            }
+        }
+
+        // Unmatched high detections above det_thresh start new tracks.
+        for &idet in &u_det_high {
+            let det = &dets_high[idet];
+            if det.score < self.det_thresh {
+                continue;
+            }
+            let mut track = BotTrack::from_detection(det, &self.kalman_filter);
+            track.activate(self.frame_id, self.next_id);
+            self.next_id += 1;
+            activated.push(track);
+        }
+
+        // Keep already-lost tracks (unmatched this frame) alive until they exceed
+        // the buffer. Tracks that just became lost in the second stage are already
+        // in `lost`, so restrict this to the originally-lost part of the pool.
+        for &i in &u_track {
+            if i >= n_tracked && self.frame_id - pool[i].frame_id <= self.buffer_size {
+                lost.push(pool[i].clone());
+            }
+        }
+
+        // Commit the frame state.
+        self.tracked_stracks = activated;
+        self.tracked_stracks.extend(refind);
+        self.lost_stracks = lost;
+
+        self.tracked_stracks
+            .iter()
+            .filter(|t| t.is_activated)
+            .cloned()
+            .collect()
+    }
+
+    /// First-stage cost matrix (`n_tracks x n_dets`).
+    ///
+    /// The IoU distance `1 - IoU`, fused with a gated cosine appearance distance when
+    /// embeddings are present: appearance is used only when it is below
+    /// `appearance_thresh` and the pair is spatially close (IoU distance below
+    /// `proximity_thresh`), and the two costs are combined by taking the smaller.
+    fn fused_cost(&self, tracks: &[BotTrack], dets: &[Detection], use_reid: bool) -> Vec<Vec<f32>> {
+        let track_boxes: Vec<[f32; 4]> = tracks.iter().map(|t| t.tlwh).collect();
+        let det_boxes: Vec<[f32; 4]> = dets.iter().map(|d| d.tlwh).collect();
+        let ious = iou_batch(&track_boxes, &det_boxes);
+
+        (0..tracks.len())
+            .map(|i| {
+                (0..dets.len())
+                    .map(|j| {
+                        let iou_dist = 1.0 - ious[i][j];
+                        let emb = self.appearance_cost(use_reid, &tracks[i], &dets[j], iou_dist);
+                        emb.map_or(iou_dist, |e| iou_dist.min(e))
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Gated cosine appearance cost for one (track, detection) pair.
+    ///
+    /// Returns `None` when appearance is unavailable or disabled. When the pair is not
+    /// spatially close or the embeddings are too dissimilar, the cost is neutralised to
+    /// `1.0` so the fused cost falls back to motion.
+    fn appearance_cost(
+        &self,
+        use_reid: bool,
+        track: &BotTrack,
+        det: &Detection,
+        iou_dist: f32,
+    ) -> Option<f32> {
+        if !use_reid {
+            return None;
+        }
+        let tf = track.smooth_feat.as_ref()?;
+        let df = det.feature.as_ref()?;
+        let mut emb = cosine_distance(tf, &l2_normalize(df));
+        if emb > self.appearance_thresh || iou_dist > self.proximity_thresh {
+            emb = 1.0;
+        }
+        Some(emb)
+    }
+}
+
+impl Default for BotSort {
+    fn default() -> Self {
+        Self::new(0.5, 30, 0.8, 0.6, 0.5, 0.25)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Python bindings
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Python-exposed BoT-SORT tracker.
+#[cfg(feature = "python")]
+#[pyclass(name = "BOTSORT")]
+pub struct PyBotSort {
+    inner: BotSort,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyBotSort {
+    #[new]
+    #[pyo3(signature = (track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6, proximity_thresh=0.5, appearance_thresh=0.25))]
+    /// Initialize the BoT-SORT tracker.
+    ///
+    /// Args:
+    ///     track_thresh (float): High/low confidence split. Default: 0.5.
+    ///     track_buffer (int): Frames a lost track is kept alive. Default: 30.
+    ///     match_thresh (float): Maximum cost for a first-stage match. Default: 0.8.
+    ///     det_thresh (float): Minimum score to start a new track. Default: 0.6.
+    ///     proximity_thresh (float): IoU-distance gate for appearance. Default: 0.5.
+    ///     appearance_thresh (float): Cosine-distance gate for appearance. Default: 0.25.
+    fn new(
+        track_thresh: f32,
+        track_buffer: usize,
+        match_thresh: f32,
+        det_thresh: f32,
+        proximity_thresh: f32,
+        appearance_thresh: f32,
+    ) -> Self {
+        Self {
+            inner: BotSort::new(
+                track_thresh,
+                track_buffer,
+                match_thresh,
+                det_thresh,
+                proximity_thresh,
+                appearance_thresh,
+            ),
+        }
+    }
+
+    /// Update the tracker with detections and optional appearance embeddings.
+    ///
+    /// Args:
+    ///     detections (list): List of ([x, y, w, h], score, class_id) tuples.
+    ///     embeddings (list): Appearance vectors, one per detection. Pass an empty
+    ///         list to track on motion only.
+    ///     camera_motion (list, optional): Six affine coefficients
+    ///         [a, b, tx, c, d, ty] mapping the previous frame to the current one.
+    ///         Defaults to no camera motion.
+    ///
+    /// Returns:
+    ///     list: Active tracks as (track_id, [x, y, w, h], score, class_id) tuples.
+    #[pyo3(signature = (detections, embeddings=Vec::new(), camera_motion=None))]
+    fn update(
+        &mut self,
+        detections: Vec<([f32; 4], f32, i64)>,
+        embeddings: Vec<Vec<f32>>,
+        camera_motion: Option<[f32; 6]>,
+    ) -> PyResult<Vec<crate::trackers::common::PyTrackingResult>> {
+        if !embeddings.is_empty() && embeddings.len() != detections.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Number of detections and embeddings must match",
+            ));
+        }
+        let cmc = camera_motion
+            .map(|m| CameraMotion::new(m[0], m[1], m[2], m[3], m[4], m[5]))
+            .unwrap_or_default();
+        let tracks = self
+            .inner
+            .update_with_camera_motion(detections, &embeddings, &cmc);
+        Ok(tracks
+            .into_iter()
+            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
+        ([x, y, w, h], s, 0)
+    }
+
+    #[test]
+    fn default_params() {
+        let t = BotSort::default();
+        assert!((t.track_thresh - 0.5).abs() < 1e-6);
+        assert_eq!(t.buffer_size, 30);
+        assert!((t.appearance_thresh - 0.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn empty_detections_return_nothing() {
+        let mut t = BotSort::default();
+        assert!(t.update(vec![], &[]).is_empty());
+    }
+
+    #[test]
+    fn single_detection_starts_a_track() {
+        let mut t = BotSort::default();
+        let tracks = t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, 1);
+        let (_, tlwh, _, _) = (tracks[0].track_id, tracks[0].tlwh, tracks[0].score, 0);
+        assert_eq!(tlwh, [100.0, 100.0, 50.0, 100.0]);
+    }
+
+    #[test]
+    fn low_score_detection_does_not_start_a_track() {
+        // Below det_thresh: no new track is created.
+        let mut t = BotSort::default();
+        assert!(
+            t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.55)], &[])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn track_keeps_id_across_frames() {
+        let mut t = BotSort::default();
+        let id = t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        let tracks = t.update(vec![det(104.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn two_objects_get_distinct_ids() {
+        let mut t = BotSort::default();
+        let tracks = t.update(
+            vec![
+                det(100.0, 100.0, 50.0, 100.0, 0.9),
+                det(400.0, 400.0, 50.0, 100.0, 0.85),
+            ],
+            &[],
+        );
+        assert_eq!(tracks.len(), 2);
+        assert_ne!(tracks[0].track_id, tracks[1].track_id);
+    }
+
+    #[test]
+    fn low_confidence_second_stage_keeps_id() {
+        // A low-confidence detection is recovered by the second association stage.
+        let mut t = BotSort::new(0.6, 30, 0.8, 0.6, 0.5, 0.25);
+        let id = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        let tracks = t.update(vec![det(12.0, 12.0, 50.0, 100.0, 0.4)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn lost_track_recovers_from_buffer() {
+        let mut t = BotSort::default();
+        let id = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        // Miss it twice: it goes lost, then stays alive in the buffer.
+        assert!(t.update(vec![], &[]).is_empty());
+        assert!(t.update(vec![], &[]).is_empty());
+        // Re-detect: the id is recovered.
+        let tracks = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn lost_track_dropped_after_buffer() {
+        let mut t = BotSort::new(0.5, 2, 0.8, 0.6, 0.5, 0.25);
+        let id = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        for _ in 0..4 {
+            t.update(vec![], &[]);
+        }
+        // Beyond the buffer, re-detection starts a fresh id.
+        let tracks = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks.len(), 1);
+        assert_ne!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn appearance_keeps_id() {
+        let mut t = BotSort::default();
+        let emb = vec![vec![1.0, 0.0, 0.0]];
+        let id = t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &emb)[0].track_id;
+        let tracks = t.update(vec![det(106.0, 100.0, 50.0, 100.0, 0.9)], &emb);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn dissimilar_appearance_falls_back_to_motion() {
+        // A dissimilar embedding is gated out, so a spatially-close detection still
+        // matches on motion and keeps the id.
+        let mut t = BotSort::default();
+        let id = t.update(
+            vec![det(100.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![1.0, 0.0, 0.0]],
+        )[0]
+        .track_id;
+        let tracks = t.update(
+            vec![det(104.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![0.0, 1.0, 0.0]],
+        );
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn camera_motion_keeps_id() {
+        // Pan the camera right by 200px; the warp moves the prediction with it.
+        let mut t = BotSort::default();
+        let id = t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        let cmc = CameraMotion::new(1.0, 0.0, 200.0, 0.0, 1.0, 0.0);
+        let tracks =
+            t.update_with_camera_motion(vec![det(300.0, 100.0, 50.0, 100.0, 0.9)], &[], &cmc);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn without_camera_motion_a_large_shift_starts_a_new_track() {
+        let mut t = BotSort::default();
+        t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        let tracks = t.update(vec![det(300.0, 100.0, 50.0, 100.0, 0.9)], &[]);
+        assert_eq!(tracks[0].track_id, 2);
+    }
+
+    #[test]
+    fn mismatched_embeddings_ignored() {
+        // Embedding count does not match detections, so appearance is skipped and
+        // tracking still runs on motion.
+        let mut t = BotSort::default();
+        let tracks = t.update(
+            vec![det(100.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![1.0], vec![2.0]],
+        );
+        assert_eq!(tracks.len(), 1);
+    }
+
+    #[test]
+    fn l2_normalize_handles_zero_vector() {
+        assert_eq!(l2_normalize(&[0.0, 0.0, 0.0]), vec![0.0, 0.0, 0.0]);
+        let unit = l2_normalize(&[3.0, 4.0]);
+        assert!((unit[0] - 0.6).abs() < 1e-6 && (unit[1] - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn feature_added_on_a_later_frame() {
+        // A track created without an embedding gains one on a later matched frame,
+        // exercising the first-feature path.
+        let mut t = BotSort::default();
+        let id = t.update(vec![det(100.0, 100.0, 50.0, 100.0, 0.9)], &[])[0].track_id;
+        let tracks = t.update(
+            vec![det(104.0, 100.0, 50.0, 100.0, 0.9)],
+            &[vec![1.0, 0.0, 0.0]],
+        );
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+
+    #[test]
+    fn reactivated_track_updates_its_feature() {
+        // A track with an embedding goes lost, then is re-detected with an embedding,
+        // exercising the feature update on re-activation.
+        let mut t = BotSort::default();
+        let emb = [vec![1.0, 0.0, 0.0]];
+        let id = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &emb)[0].track_id;
+        assert!(t.update(vec![], &[]).is_empty());
+        assert!(t.update(vec![], &[]).is_empty());
+        let tracks = t.update(vec![det(10.0, 10.0, 50.0, 100.0, 0.9)], &emb);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].track_id, id);
+    }
+}

--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -3,26 +3,12 @@
 use crate::trackers::byte_track::TrackState;
 use crate::trackers::common::{CameraMotion, KalmanTrack};
 use crate::utils::assignment::{greedy_match, iou_match};
+use crate::utils::features::{cosine_distance, l2_normalize};
 use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
 use crate::utils::kalman::KalmanFilter;
 
 /// Exponential moving-average weight for the per-track appearance feature.
 const FEATURE_MOMENTUM: f32 = 0.9;
-
-/// L2-normalise a feature vector, returning zeros unchanged.
-fn l2_normalize(feature: &[f32]) -> Vec<f32> {
-    let norm = feature.iter().map(|v| v * v).sum::<f32>().sqrt();
-    if norm <= 1e-12 {
-        return feature.to_vec();
-    }
-    feature.iter().map(|v| v / norm).collect()
-}
-
-/// Cosine distance between two L2-normalised vectors, clamped to `[0, 2]`.
-fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
-    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
-    (1.0 - dot).clamp(0.0, 2.0)
-}
 
 /// A detection with an optional appearance embedding.
 struct Detection {
@@ -91,8 +77,8 @@ impl BotTrack {
         self.tracklet_len = 0;
     }
 
-    /// Correct a matched track with a new detection.
-    fn update(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+    /// Kalman-correct with a matched detection and adopt its box, score, and class.
+    fn absorb(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
         self.kalman.update(&tlwh_to_xyah(&det.tlwh), kf);
         self.tlwh = det.tlwh;
         self.score = det.score;
@@ -100,25 +86,21 @@ impl BotTrack {
         self.state = TrackState::Tracked;
         self.is_activated = true;
         self.frame_id = frame_id;
-        self.tracklet_len += 1;
         if let Some(f) = &det.feature {
             self.update_features(f);
         }
     }
 
+    /// Continue an already-tracked track (extends the tracklet).
+    fn update(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+        self.absorb(det, frame_id, kf);
+        self.tracklet_len += 1;
+    }
+
     /// Bring a lost track back with a matched detection, keeping its id.
     fn re_activate(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
-        self.kalman.update(&tlwh_to_xyah(&det.tlwh), kf);
-        self.tlwh = det.tlwh;
-        self.score = det.score;
-        self.class_id = det.class_id;
-        self.state = TrackState::Tracked;
-        self.is_activated = true;
-        self.frame_id = frame_id;
+        self.absorb(det, frame_id, kf);
         self.tracklet_len = 0;
-        if let Some(f) = &det.feature {
-            self.update_features(f);
-        }
     }
 
     /// Kalman-predict one step forward, damping height velocity while not tracked.
@@ -421,7 +403,7 @@ impl BotSort {
         }
         let tf = track.smooth_feat.as_ref()?;
         let df = det.feature.as_ref()?;
-        let mut emb = cosine_distance(tf, &l2_normalize(df));
+        let mut emb = cosine_distance(tf, df);
         if emb > self.appearance_thresh || iou_dist > self.proximity_thresh {
             emb = 1.0;
         }
@@ -679,13 +661,6 @@ mod tests {
             &[vec![1.0], vec![2.0]],
         );
         assert_eq!(tracks.len(), 1);
-    }
-
-    #[test]
-    fn l2_normalize_handles_zero_vector() {
-        assert_eq!(l2_normalize(&[0.0, 0.0, 0.0]), vec![0.0, 0.0, 0.0]);
-        let unit = l2_normalize(&[3.0, 4.0]);
-        assert!((unit[0] - 0.6).abs() < 1e-6 && (unit[1] - 0.8).abs() < 1e-6);
     }
 
     #[test]

--- a/src/trackers/deepsort/nn_matching.rs
+++ b/src/trackers/deepsort/nn_matching.rs
@@ -96,7 +96,7 @@ impl NearestNeighborDistanceMetric {
         for sample in samples {
             let dist = match self.metric {
                 Metric::Euclidean => euclidean_distance(sample, feature),
-                Metric::Cosine => cosine_distance(sample, feature),
+                Metric::Cosine => crate::utils::features::cosine_distance(sample, feature),
             };
             if dist < min_dist {
                 min_dist = dist;
@@ -118,25 +118,6 @@ fn euclidean_distance(a: &[f32], b: &[f32]) -> f32 {
     sum.sqrt()
 }
 
-fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
-    // 1 - (a . b) / (|a| * |b|)
-    // Assuming normalized features, it's just 1 - a . b
-    // But let's be safe and compute norms.
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-
-    let cosine_sim = if norm_a > 1e-6 && norm_b > 1e-6 {
-        dot / (norm_a * norm_b)
-    } else {
-        0.0
-    };
-
-    // Clamp to [0, 1] for safety in case of float errors, though dot/norms should be <= 1.
-    // Distance is 1 - similarity.
-    (1.0 - cosine_sim).max(0.0)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,42 +127,6 @@ mod tests {
         let a = vec![0.0, 0.0];
         let b = vec![3.0, 4.0];
         assert!((euclidean_distance(&a, &b) - 5.0).abs() < 1e-5);
-    }
-
-    #[test]
-    fn test_cosine() {
-        let a = vec![1.0, 0.0];
-        let b = vec![0.0, 1.0];
-        // Orthogonal -> dist 1.0
-        assert!((cosine_distance(&a, &b) - 1.0).abs() < 1e-5);
-
-        let c = vec![1.0, 0.0];
-        // Same -> dist 0.0
-        assert!((cosine_distance(&a, &c)).abs() < 1e-5);
-    }
-
-    #[test]
-    fn test_cosine_parallel() {
-        // Parallel vectors should have distance ~0
-        let a = vec![1.0, 1.0];
-        let b = vec![2.0, 2.0]; // Same direction, different magnitude
-        assert!(cosine_distance(&a, &b) < 0.01);
-    }
-
-    #[test]
-    fn test_cosine_opposite() {
-        // Opposite vectors should have distance ~2
-        let a = vec![1.0, 0.0];
-        let b = vec![-1.0, 0.0];
-        assert!((cosine_distance(&a, &b) - 2.0).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_cosine_zero_norm() {
-        // Zero vector should return 1.0 (no similarity)
-        let a = vec![0.0, 0.0];
-        let b = vec![1.0, 1.0];
-        assert!((cosine_distance(&a, &b) - 1.0).abs() < 0.01);
     }
 
     #[test]

--- a/src/trackers/mod.rs
+++ b/src/trackers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains the core tracking logic for algorithms like ByteTrack, SORT, DeepSORT, and OC-SORT.
 
+pub mod botsort;
 pub mod byte_track;
 pub mod common;
 pub mod deep_ocsort;

--- a/src/utils/features.rs
+++ b/src/utils/features.rs
@@ -1,0 +1,72 @@
+//! Appearance-feature helpers shared by the Re-ID trackers.
+//!
+//! DeepSORT's feature gallery and BoT-SORT's per-track embedding both need the same
+//! two operations: L2-normalise a vector and measure the cosine distance between two
+//! vectors. They live here so there is one tested implementation.
+
+/// L2-normalise a feature vector.
+///
+/// A zero (or near-zero) vector is returned unchanged, so callers never divide by zero.
+pub fn l2_normalize(feature: &[f32]) -> Vec<f32> {
+    let norm = feature.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if norm <= 1e-12 {
+        return feature.to_vec();
+    }
+    feature.iter().map(|v| v / norm).collect()
+}
+
+/// Cosine distance between two vectors, in `[0, 2]`.
+///
+/// Each vector is normalised internally, so the inputs need not be unit length.
+/// Identical directions give `0`, orthogonal give `1`, opposite give `2`. A
+/// zero-norm input yields `1` (no similarity).
+pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    let cosine_sim = if norm_a > 1e-6 && norm_b > 1e-6 {
+        dot / (norm_a * norm_b)
+    } else {
+        0.0
+    };
+    (1.0 - cosine_sim).max(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn l2_normalize_makes_unit_vectors() {
+        let unit = l2_normalize(&[3.0, 4.0]);
+        assert!((unit[0] - 0.6).abs() < 1e-6 && (unit[1] - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn l2_normalize_leaves_zero_vector() {
+        assert_eq!(l2_normalize(&[0.0, 0.0, 0.0]), vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn cosine_orthogonal_and_identical() {
+        assert!((cosine_distance(&[1.0, 0.0], &[0.0, 1.0]) - 1.0).abs() < 1e-5);
+        assert!(cosine_distance(&[1.0, 0.0], &[1.0, 0.0]).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_ignores_magnitude() {
+        // Same direction, different magnitude -> distance ~0.
+        assert!(cosine_distance(&[1.0, 1.0], &[2.0, 2.0]) < 0.01);
+    }
+
+    #[test]
+    fn cosine_opposite_is_two() {
+        assert!((cosine_distance(&[1.0, 0.0], &[-1.0, 0.0]) - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn cosine_zero_norm_is_one() {
+        assert!((cosine_distance(&[0.0, 0.0], &[1.0, 1.0]) - 1.0).abs() < 0.01);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,5 +3,6 @@
 //! This module provides common mathematical and geometric tools used by the trackers.
 
 pub mod assignment;
+pub mod features;
 pub mod geometry;
 pub mod kalman;

--- a/tests/test_botsort_scenarios.py
+++ b/tests/test_botsort_scenarios.py
@@ -1,0 +1,94 @@
+"""End-to-end BoT-SORT tracking scenarios.
+
+These drive the tracker over multiple frames with synthetic detections (no detector)
+and assert real tracking behaviour: stable ids, occlusion recovery, camera-motion
+compensation, appearance disambiguation through a crossing, and motion-only parity
+with ByteTrack.
+"""
+
+import trackforge
+
+
+def box(x, y, w=40, h=80):
+    return [float(x), float(y), float(w), float(h)]
+
+
+def id_near(tracks, near_x):
+    """Return the id of the track whose box center-x is closest to ``near_x``."""
+    return min(tracks, key=lambda t: abs(t[1][0] - near_x))[0]
+
+
+def test_two_objects_moving_keep_stable_distinct_ids():
+    t = trackforge.BOTSORT()
+    seen_a, seen_b = set(), set()
+    for f in range(20):
+        dets = [(box(100 + f * 8, 100), 0.9, 0), (box(500 - f * 6, 300), 0.85, 0)]
+        tracks = t.update(dets)
+        assert len(tracks) == 2, f"frame {f}: expected 2 tracks, got {len(tracks)}"
+        seen_a.add(id_near(tracks, 100 + f * 8))
+        seen_b.add(id_near(tracks, 500 - f * 6))
+    assert len(seen_a) == 1, f"object A changed id: {seen_a}"
+    assert len(seen_b) == 1, f"object B changed id: {seen_b}"
+    assert seen_a != seen_b
+
+
+def test_occlusion_recovery_keeps_id():
+    t = trackforge.BOTSORT(track_buffer=30)
+    tid = t.update([(box(200, 200), 0.9, 0)])[0][0]
+    for f in range(1, 6):
+        assert t.update([]) == [], f"frame {f}: track should be hidden while occluded"
+    tracks = t.update([(box(205, 200), 0.9, 0)])
+    assert len(tracks) == 1
+    assert tracks[0][0] == tid, f"id not recovered: {tracks[0][0]} != {tid}"
+
+
+def test_camera_pan_keeps_id():
+    t = trackforge.BOTSORT()
+    tid = t.update([(box(400, 200), 0.9, 0)])[0][0]
+    for f in range(1, 8):
+        # Camera pans right 30px/frame: the object appears to move right, but the
+        # affine [1, 0, 30, 0, 1, 0] warps the prediction so the id holds.
+        appear_x = 400 + f * 30
+        cmc = [1.0, 0.0, 30.0, 0.0, 1.0, 0.0]
+        tracks = t.update([(box(appear_x, 200), 0.9, 0)], [], cmc)
+        assert len(tracks) == 1, f"frame {f}: lost the track under pan"
+        assert tracks[0][0] == tid, f"frame {f}: id changed under pan ({tracks[0][0]})"
+
+
+def test_appearance_prevents_swap_through_crossing():
+    # Frame 0 assigns id 1 to object A (starts left, emb_a, moves right) and id 2 to
+    # object B (starts right, emb_b, moves left). If appearance holds through the
+    # crossing, id 1 ends on the right and id 2 on the left; a swap would flip that.
+    t = trackforge.BOTSORT(appearance_thresh=0.4)
+    emb_a = [1.0, 0.0, 0.0]
+    emb_b = [0.0, 1.0, 0.0]
+    x1_first = x2_first = None
+    x1_last = x2_last = None
+    for f in range(12):
+        ax, bx = 200 + f * 20, 440 - f * 20
+        tracks = t.update(
+            [(box(ax, 200), 0.9, 0), (box(bx, 200), 0.9, 1)], [emb_a, emb_b]
+        )
+        assert len(tracks) == 2, f"frame {f}: expected 2 tracks, got {len(tracks)}"
+        by_id = {trk[0]: trk[1][0] for trk in tracks}
+        assert set(by_id) == {1, 2}, (
+            f"frame {f}: unexpected ids {set(by_id)} (fragmentation)"
+        )
+        if f == 0:
+            x1_first, x2_first = by_id[1], by_id[2]
+        x1_last, x2_last = by_id[1], by_id[2]
+    assert x1_last > x1_first, (
+        f"id 1 did not follow the rightward object: {x1_first}->{x1_last}"
+    )
+    assert x2_last < x2_first, (
+        f"id 2 did not follow the leftward object: {x2_first}->{x2_last}"
+    )
+
+
+def test_motion_only_parity_with_bytetrack():
+    # With no embeddings and no camera motion, BoT-SORT tracks like ByteTrack.
+    bt = trackforge.BYTETRACK()
+    bs = trackforge.BOTSORT()
+    for f in range(10):
+        dets = [(box(150 + f * 10, 250), 0.9, 0)]
+        assert len(bt.update(dets)) == len(bs.update(dets)) == 1, f"frame {f}: mismatch"

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -213,3 +213,61 @@ def test_deepocsort_camera_motion_keeps_id():
     second = t.update([([300.0, 100.0, 50.0, 100.0], 0.9, 0)], [], camera_motion)
     assert len(second) == 1
     assert second[0][0] == track_id
+
+
+# ---------------------------------------------------------------------------
+# BOTSORT
+# ---------------------------------------------------------------------------
+
+
+def test_botsort_constructor():
+    t = trackforge.BOTSORT(
+        track_thresh=0.5,
+        track_buffer=30,
+        match_thresh=0.8,
+        det_thresh=0.6,
+        proximity_thresh=0.5,
+        appearance_thresh=0.25,
+    )
+    assert t is not None
+
+
+def test_botsort_update_empty():
+    t = trackforge.BOTSORT()
+    assert t.update([]) == []
+
+
+def test_botsort_motion_only():
+    t = trackforge.BOTSORT()
+    tracks = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
+    assert len(tracks) == 1
+    track_id, tlwh, score, class_id = tracks[0]
+    assert track_id == 1
+    assert len(tlwh) == 4
+
+
+def test_botsort_with_embeddings_keeps_id():
+    t = trackforge.BOTSORT()
+    emb = [[1.0, 0.0, 0.0]]
+    first = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)], emb)
+    track_id = first[0][0]
+    second = t.update([([106.0, 100.0, 50.0, 100.0], 0.9, 0)], emb)
+    assert len(second) == 1
+    assert second[0][0] == track_id
+
+
+def test_botsort_mismatched_embeddings_raises():
+    t = trackforge.BOTSORT()
+    with pytest.raises(ValueError):
+        t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)], [[1.0], [2.0]])
+
+
+def test_botsort_camera_motion_keeps_id():
+    t = trackforge.BOTSORT()
+    first = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
+    track_id = first[0][0]
+    # Camera pans right by 200px; the object now appears at x=300.
+    camera_motion = [1.0, 0.0, 200.0, 0.0, 1.0, 0.0]
+    second = t.update([([300.0, 100.0, 50.0, 100.0], 0.9, 0)], [], camera_motion)
+    assert len(second) == 1
+    assert second[0][0] == track_id


### PR DESCRIPTION
Adds BoT-SORT ([arXiv:2206.14651](https://arxiv.org/abs/2206.14651)), built on the shared base from #123.

BoT-SORT keeps ByteTrack's two-stage cascade and adds two things:

- **Camera motion compensation** warps each track's Kalman prediction by a caller-supplied affine before association, so tracking survives panning and zooming cameras. It uses the existing `common::cmc`.
- **Appearance fusion** combines a cosine distance to a per-track appearance embedding (kept as an exponential moving average) with the IoU distance in the high-confidence stage. Appearance is used only when it is confident and the pair is spatially close; the fused cost is the smaller of the two. With no embeddings the tracker reduces to ByteTrack with camera motion.

