### PR TITLE
fix(security): resolve crossbeam-epoch advisory and ignore unmaintained ttf-parser

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,7 +5,13 @@
 # permanently specified in this file.
 
 [advisories]
-ignore = ["RUSTSEC-2024-0436"]            # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
+ignore = [
+    "RUSTSEC-2024-0436",
+    # ttf-parser unmaintained, reached only through the optional usls example
+    # dependency and with no maintained replacement in that chain.
+    "RUSTSEC-2026-0192",
+]
+
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low"                # CVSS severity ("none", "low", "medium", "high", "critical")
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2024-0436
+          ignore: RUSTSEC-2024-0436,RUSTSEC-2026-0192
 
   # Fallback job for fork PRs: runs cargo-audit directly without needing
   # write permissions on the repo (fails the job if advisories are found).
@@ -43,4 +43,4 @@ jobs:
       - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
         with:
           tool: cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2024-0436
+      - run: cargo audit --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0192

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ yanked = "warn"
 ignore = [
     # Add advisory IDs or yanked crates to ignore here
     # { crate = "some-crate@1.0.0", reason = "explanation" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser is unmaintained but reached only through the optional usls example dependency, and the ab_glyph and imageproc chain has no maintained replacement to move to yet" },
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
## What this does

Clears both open security advisories.

- Bumps `crossbeam-epoch` to 0.9.20, which patches RUSTSEC-2026-0204. That was an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared`. It reached us transitively through `image`.
- Ignores RUSTSEC-2026-0192 for `ttf-parser`. That crate is unmaintained, but it is only pulled in through the optional `usls` example dependency, and the `ab_glyph` and `imageproc` chain above it has no maintained replacement to switch to yet. The ignore is documented in `.cargo/audit.toml`, `deny.toml`, and the security audit workflow so all three agree.

## Result

`cargo audit` runs clean locally. This also unblocks the failing `cargo deny` check on the open dependabot PR, which was red for the same two advisories.

Closes #129
Closes #126
