### PR TITLE
feat(features): add optional reid-model feature for the image extractor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,15 @@ name = "trackforge"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-image = "0.25.9"
+image = { version = "0.25.9", optional = true }
 nalgebra = "0.35.0"
 pyo3 = { version = "0.29.0", features = ["extension-module"], optional = true }
 
 [features]
 default = []
 python = ["dep:pyo3"]
-advanced_examples = ["dep:ndarray", "dep:opencv", "dep:ort", "dep:usls"]
+reid-model = ["dep:image"]
+advanced_examples = ["reid-model", "dep:ndarray", "dep:opencv", "dep:ort", "dep:usls"]
 
 [[example]]
 name = "byte_track_demo"
@@ -47,6 +48,7 @@ required-features = ["advanced_examples"]
 [[example]]
 name = "deepsort_simple"
 path = "examples/deepsort_simple.rs"
+required-features = ["reid-model"]
 
 [dev-dependencies]
 # Testing dependencies

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - 🚀 **Native Rust Core** Blazingly fast tracking (< 1ms/frame for ByteTrack) with full memory safety
 - 🐍 **Python Bindings** First-class `pip install trackforge` support via PyO3
 - 🎯 **Multi-Algorithm** ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, BoT-SORT, and SORT with a unified API
-- 🔌 **Pluggable Re-ID** DeepSORT's appearance extractor is a trait; plug in any feature model
+- 🔌 **Pluggable Re-ID** The appearance matching is always available; you pass in embeddings. The image based extractor that runs a model over a frame is an opt-in `reid-model` feature, so the base build stays light
 - 📐 **Generic Kalman Filter** Configurable position/velocity weighting, gating distance computation
 
 <!-- prettier-ignore -->
@@ -71,6 +71,25 @@ To build the Python bindings from source (e.g., via `maturin develop`), enable t
 [dependencies]
 trackforge = { version = "0.3.0", features = ["python"] }
 ```
+
+#### Cargo features
+
+The default build is light and pulls no image codecs. Every tracker works on detections you pass in, and the appearance trackers work on embeddings you pass in.
+
+| Feature | What it adds | Extra dependency |
+| ------- | ------------ | ---------------- |
+| default | All trackers, embedding based appearance matching, Kalman core | none |
+| `reid-model` | The `AppearanceExtractor` trait plus the `DeepSort` and `DeepOcSort` wrappers that run a model over a frame to produce embeddings | `image` |
+| `python` | PyO3 bindings for the Python package | `pyo3` |
+
+Enable the image based extractor when you want the library to produce embeddings for you:
+
+```toml
+[dependencies]
+trackforge = { version = "0.3.0", features = ["reid-model"] }
+```
+
+Without it, produce embeddings yourself (any model, any runtime) and drive `DeepSortTracker` or `DeepOcSortTracker` directly.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ trackforge = { version = "0.3.0", features = ["python"] }
 
 The default build is light and pulls no image codecs. Every tracker works on detections you pass in, and the appearance trackers work on embeddings you pass in.
 
-| Feature | What it adds | Extra dependency |
-| ------- | ------------ | ---------------- |
-| default | All trackers, embedding based appearance matching, Kalman core | none |
-| `reid-model` | The `AppearanceExtractor` trait plus the `DeepSort` and `DeepOcSort` wrappers that run a model over a frame to produce embeddings | `image` |
-| `python` | PyO3 bindings for the Python package | `pyo3` |
+| Feature      | What it adds                                                                                                                      | Extra dependency |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| default      | All trackers, embedding based appearance matching, Kalman core                                                                    | none             |
+| `reid-model` | The `AppearanceExtractor` trait plus the `DeepSort` and `DeepOcSort` wrappers that run a model over a frame to produce embeddings | `image`          |
+| `python`     | PyO3 bindings for the Python package                                                                                              | `pyo3`           |
 
 Enable the image based extractor when you want the library to produce embeddings for you:
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -9,6 +9,13 @@
 trackforge = "0.3"
 ```
 
+The default build is light and pulls no image codecs. Every tracker runs on detections you pass in, and the appearance trackers run on embeddings you pass in. To have the library produce embeddings for you by running a model over a frame, enable the `reid-model` feature, which adds the `AppearanceExtractor` trait and the `DeepSort` and `DeepOcSort` wrappers along with the `image` crate.
+
+```toml
+[dependencies]
+trackforge = { version = "0.3", features = ["reid-model"] }
+```
+
 ### Python
 
 ```bash

--- a/book/src/trackers/deepsort.md
+++ b/book/src/trackers/deepsort.md
@@ -8,6 +8,8 @@ identity maintenance.
 Unlike the other trackers, DeepSORT needs an appearance embedding per detection. In Rust you supply
 an `AppearanceExtractor`; in Python you pass embeddings directly.
 
+The `AppearanceExtractor` trait and the `DeepSort` wrapper below live behind the `reid-model` feature, which adds the `image` crate. Enable it with `features = ["reid-model"]`. If you already have embeddings, skip the extractor and drive `DeepSortTracker` directly on the default build.
+
 ## Rust: implement an extractor
 
 ```rust,ignore

--- a/docs/index.md
+++ b/docs/index.md
@@ -297,7 +297,7 @@ to IoU matching. Provides robust long-term identity maintenance.
 
 ### Implementing an AppearanceExtractor (Rust)
 
-DeepSORT requires you to supply a feature extractor. Implement the `AppearanceExtractor` trait:
+DeepSORT requires you to supply a feature extractor. Implement the `AppearanceExtractor` trait, which lives behind the `reid-model` feature (`features = ["reid-model"]`); on the default build, produce embeddings yourself and drive `DeepSortTracker` directly:
 
 ```rust,ignore
 use trackforge::traits::AppearanceExtractor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //! # DeepSORT
 //!
 //! Augments IoU matching with Re-ID appearance embeddings for reliable re-identification
-//! across long occlusions. Requires an [`AppearanceExtractor`] implementation that produces
+//! across long occlusions. Requires an `AppearanceExtractor` implementation that produces
 //! a feature vector for each detected crop.
 //!
 //! ```rust,ignore
@@ -132,7 +132,7 @@
 //!
 //! Extends OC-SORT with an appearance term: a cosine distance to a per-track feature
 //! gallery is blended into the motion cost, scaled by detector confidence. Like
-//! DeepSORT it needs an [`AppearanceExtractor`], or embeddings passed directly.
+//! DeepSORT it needs an `AppearanceExtractor`, or embeddings passed directly.
 //!
 //! ```rust,ignore
 //! use trackforge::trackers::deep_ocsort::DeepOcSort;
@@ -159,7 +159,6 @@
 //! [`deepsort`]: trackers::deepsort
 //! [`deep_ocsort`]: trackers::deep_ocsort
 //! [`botsort`]: trackers::botsort
-//! [`AppearanceExtractor`]: traits::AppearanceExtractor
 
 pub mod trackers;
 pub mod traits;

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -15,10 +15,10 @@ pub mod python;
 pub use crate::trackers::common::ObsTrack as DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
-#[cfg(any(feature = "python", feature = "reid-model"))]
-use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
 #[cfg(feature = "reid-model")]
 use crate::trackers::common::CameraMotion;
+#[cfg(any(feature = "python", feature = "reid-model"))]
+use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
 #[cfg(feature = "reid-model")]
 use crate::traits::AppearanceExtractor;
 #[cfg(feature = "reid-model")]

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -15,14 +15,21 @@ pub mod python;
 pub use crate::trackers::common::ObsTrack as DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
-use crate::trackers::common::CameraMotion;
+#[cfg(any(feature = "python", feature = "reid-model"))]
 use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
+#[cfg(feature = "reid-model")]
+use crate::trackers::common::CameraMotion;
+#[cfg(feature = "reid-model")]
 use crate::traits::AppearanceExtractor;
+#[cfg(feature = "reid-model")]
 use crate::types::BoundingBox;
+#[cfg(feature = "reid-model")]
 use image::DynamicImage;
+#[cfg(feature = "reid-model")]
 use std::error::Error;
 
 /// Build the inner Deep OC-SORT tracker shared by the Rust and Python constructors.
+#[cfg(any(feature = "python", feature = "reid-model"))]
 #[allow(clippy::too_many_arguments)]
 fn build_tracker(
     max_age: usize,
@@ -53,11 +60,13 @@ fn build_tracker(
 /// Wraps the association core with an [`AppearanceExtractor`] so the caller can pass a
 /// frame and detections and have the embeddings produced internally. To pass
 /// embeddings directly, drive [`DeepOcSortTracker`] instead.
+#[cfg(feature = "reid-model")]
 pub struct DeepOcSort<E: AppearanceExtractor> {
     extractor: E,
     tracker: DeepOcSortTracker,
 }
 
+#[cfg(feature = "reid-model")]
 impl<E: AppearanceExtractor> DeepOcSort<E> {
     /// Create a new Deep OC-SORT tracker.
     ///
@@ -151,7 +160,7 @@ impl<E: AppearanceExtractor> DeepOcSort<E> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "reid-model"))]
 mod tests {
     use super::*;
 

--- a/src/trackers/deepsort/README.md
+++ b/src/trackers/deepsort/README.md
@@ -11,7 +11,7 @@
 
 ## Usage
 
-```rust
+```rust,ignore
 use trackforge::trackers::deepsort::DeepSort;
 use trackforge::traits::AppearanceExtractor;
 use trackforge::types::BoundingBox;

--- a/src/trackers/deepsort/mod.rs
+++ b/src/trackers/deepsort/mod.rs
@@ -13,12 +13,17 @@ pub use nn_matching::{Metric, NearestNeighborDistanceMetric};
 pub use track::{Track, TrackState};
 pub use tracker::DeepSortTracker;
 
+#[cfg(feature = "reid-model")]
 use crate::traits::AppearanceExtractor;
+#[cfg(feature = "reid-model")]
 use crate::types::BoundingBox;
+#[cfg(feature = "reid-model")]
 use image::DynamicImage;
+#[cfg(feature = "reid-model")]
 use std::error::Error;
 
 /// Build the inner DeepSORT tracker shared by the Rust and Python constructors.
+#[cfg(any(feature = "python", feature = "reid-model"))]
 fn build_tracker(
     max_age: usize,
     n_init: usize,
@@ -33,12 +38,15 @@ fn build_tracker(
 
 /// Deep SORT tracker implementation.
 ///
-/// Wraps the tracker logic and appearance feature extraction.
+/// Wraps the tracker logic and appearance feature extraction. To pass embeddings
+/// directly without the `image`-based extractor, drive [`DeepSortTracker`] instead.
+#[cfg(feature = "reid-model")]
 pub struct DeepSort<E: AppearanceExtractor> {
     extractor: E,
     tracker: DeepSortTracker,
 }
 
+#[cfg(feature = "reid-model")]
 impl<E: AppearanceExtractor> DeepSort<E> {
     /// Create a new Deep SORT tracker.
     ///
@@ -111,13 +119,14 @@ impl<E: AppearanceExtractor> DeepSort<E> {
 }
 
 // Default convenience constructor
+#[cfg(feature = "reid-model")]
 impl<E: AppearanceExtractor> DeepSort<E> {
     pub fn new_default(extractor: E) -> Self {
         Self::new(extractor, 70, 3, 0.7, 0.2, 100)
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "reid-model"))]
 mod tests {
     use super::*;
     use crate::types::BoundingBox;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "reid-model")]
 use crate::types::BoundingBox;
+#[cfg(feature = "reid-model")]
 use image::DynamicImage;
+#[cfg(feature = "reid-model")]
 use std::error::Error;
 
 /// A detection passed to a tracker: `(tlwh, score, class_id)`.
@@ -38,7 +41,9 @@ pub trait Tracker {
 /// Trait for extracting appearance features (embeddings) from images.
 ///
 /// This allows decoupling the tracker logic (DeepSORT) from the model execution
-/// (ONNX, PyTorch via Python, etc.).
+/// (ONNX, PyTorch via Python, etc.). Gated behind the `reid-model` feature, which pulls
+/// in the `image` crate; the default build omits it so the base package stays light.
+#[cfg(feature = "reid-model")]
 pub trait AppearanceExtractor {
     /// Extract features for a list of bounding boxes from a given image.
     ///


### PR DESCRIPTION
Splits Re-ID into the algorithm side and the model side.

The algorithm side, embedding based appearance matching, stays in the base build for every appearance tracker. You pass embeddings in and drive `DeepSortTracker` or `DeepOcSortTracker` directly.

The model side, the `AppearanceExtractor` trait and the `DeepSort` and `DeepOcSort` wrappers that run a model over a frame, now lives behind a new `reid-model` feature that adds the `image` crate. The default build no longer pulls the image codec tree.

Docs updated: README, the mdBook getting-started and DeepSORT pages, and the docs site.
