### PR TITLE
test(trackers): leak and id stress tests, restore deep_ocsort core coverage

### DIFF
--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -690,4 +690,21 @@ mod tests {
         assert_eq!(tracks.len(), 1);
         assert_eq!(tracks[0].track_id, id);
     }
+
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // A fresh object each frame that never re-matches. Lost tracks must age out
+        // of the buffer rather than accumulate with the frame count.
+        let buffer = 30;
+        let mut t = BotSort::new(0.5, buffer, 0.8, 0.6, 0.5, 0.25);
+        for f in 0..3000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0;
+            let _ = t.update(vec![det(x, 10.0, 20.0, 40.0, 0.9)], &[]);
+            let stored = t.tracked_stracks.len() + t.lost_stracks.len();
+            assert!(
+                stored <= buffer + 5,
+                "storage grew to {stored} at frame {f}, buffer is {buffer}"
+            );
+        }
+    }
 }

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -506,4 +506,46 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].track_id, id, "track recovered from the lost buffer");
     }
+
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // Every frame a brand-new object appears far from any previous one and then
+        // vanishes, so nothing ever re-matches. Lost tracks must age out of the
+        // buffer instead of piling up. The internal vectors must stay bounded by the
+        // buffer window, not grow with the frame count.
+        let buffer = 30;
+        let mut tracker = ByteTrack::new(0.5, buffer, 0.8, 0.6);
+        for f in 0..3000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0; // spaced apart, cycle exceeds buffer
+            let _ = tracker.update(vec![([x, 10.0, 20.0, 40.0], 0.9, 0)]);
+            let stored = tracker.tracked_stracks.len() + tracker.lost_stracks.len();
+            assert!(
+                stored <= buffer + 5,
+                "storage grew to {stored} at frame {f}, buffer is {buffer}"
+            );
+        }
+    }
+
+    #[test]
+    fn active_ids_are_unique_each_frame() {
+        // Five persistent objects; every active id in a frame must be distinct.
+        let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        for f in 0..200 {
+            let dets: Vec<_> = (0..5)
+                .map(|i| {
+                    let x = 20.0 + i as f32 * 120.0 + (f % 3) as f32;
+                    ([x, 30.0, 40.0, 80.0], 0.9, i)
+                })
+                .collect();
+            let out = tracker.update(dets);
+            let mut ids: Vec<u64> = out.iter().map(|t| t.track_id).collect();
+            ids.sort_unstable();
+            let unique = {
+                let mut u = ids.clone();
+                u.dedup();
+                u.len()
+            };
+            assert_eq!(ids.len(), unique, "duplicate id in frame {f}: {ids:?}");
+        }
+    }
 }

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -15,9 +15,9 @@ pub mod python;
 pub use crate::trackers::common::ObsTrack as DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
-#[cfg(feature = "reid-model")]
+#[cfg(any(test, feature = "reid-model"))]
 use crate::trackers::common::CameraMotion;
-#[cfg(any(feature = "python", feature = "reid-model"))]
+#[cfg(any(test, feature = "python", feature = "reid-model"))]
 use crate::trackers::deepsort::{Metric, NearestNeighborDistanceMetric};
 #[cfg(feature = "reid-model")]
 use crate::traits::AppearanceExtractor;
@@ -29,7 +29,7 @@ use image::DynamicImage;
 use std::error::Error;
 
 /// Build the inner Deep OC-SORT tracker shared by the Rust and Python constructors.
-#[cfg(any(feature = "python", feature = "reid-model"))]
+#[cfg(any(test, feature = "python", feature = "reid-model"))]
 #[allow(clippy::too_many_arguments)]
 fn build_tracker(
     max_age: usize,
@@ -160,7 +160,7 @@ impl<E: AppearanceExtractor> DeepOcSort<E> {
     }
 }
 
-#[cfg(all(test, feature = "reid-model"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -213,7 +213,27 @@ mod tests {
         assert_eq!(t2[0].track_id, id);
     }
 
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // A fresh object each frame that never re-matches. The track vector stays
+        // bounded by the max_age window, and the gallery is capped by nn_budget and
+        // pruned to active tracks (see nn_matching tests).
+        let max_age = 20;
+        let mut tracker = build_tracker(max_age, 3, 0.3, 3, 0.2, 0.5, 0.2, 100);
+        for f in 0..2000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0;
+            let _ = tracker.update(&[det(x, 10.0, 20.0, 40.0, 0.9)], &[]);
+            assert!(
+                tracker.tracks.len() <= max_age + 5,
+                "tracks grew to {} at frame {f}",
+                tracker.tracks.len()
+            );
+        }
+    }
+
+    #[cfg(feature = "reid-model")]
     struct MockExtractor;
+    #[cfg(feature = "reid-model")]
     impl AppearanceExtractor for MockExtractor {
         fn extract(
             &mut self,
@@ -224,7 +244,9 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "reid-model")]
     struct FailingExtractor;
+    #[cfg(feature = "reid-model")]
     impl AppearanceExtractor for FailingExtractor {
         fn extract(
             &mut self,
@@ -235,6 +257,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "reid-model")]
     #[test]
     fn wrapper_propagates_extractor_error() {
         let mut tracker = DeepOcSort::new_default(FailingExtractor);
@@ -243,6 +266,7 @@ mod tests {
         assert!(tracker.update(&image, dets).is_err());
     }
 
+    #[cfg(feature = "reid-model")]
     #[test]
     fn extractor_wrapper_confirms_track() {
         let mut tracker = DeepOcSort::new(MockExtractor, 30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
@@ -252,6 +276,7 @@ mod tests {
         assert_eq!(tracks.len(), 1);
     }
 
+    #[cfg(feature = "reid-model")]
     #[test]
     fn new_default_runs_through_wrapper() {
         let mut tracker = DeepOcSort::new_default(MockExtractor);
@@ -264,6 +289,7 @@ mod tests {
         assert_eq!(tracker.update(&image, dets).unwrap().len(), 1);
     }
 
+    #[cfg(feature = "reid-model")]
     #[test]
     fn wrapper_applies_camera_motion() {
         let mut tracker = DeepOcSort::new(MockExtractor, 30, 1, 0.3, 3, 0.2, 0.5, 0.2, 100);
@@ -287,6 +313,7 @@ mod tests {
         assert_eq!(tracks[0].track_id, id);
     }
 
+    #[cfg(feature = "reid-model")]
     #[test]
     fn wrapper_handles_empty_detections() {
         let mut tracker = DeepOcSort::new_default(MockExtractor);

--- a/src/trackers/deepsort/tracker.rs
+++ b/src/trackers/deepsort/tracker.rs
@@ -717,4 +717,24 @@ mod tests {
         }
         assert_eq!(tracker.tracks[1].track_id, 2);
     }
+
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // A fresh object each frame that never re-matches. The track vector must
+        // stay bounded by the max_age window, and the gallery is capped by the
+        // nn_budget and pruned to active tracks (see nn_matching tests).
+        let mut tracker = create_tracker(); // max_age = 30, nn_budget = 100
+        let emb = vec![1.0_f32; 128];
+        for f in 0..2000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0;
+            let det = (BoundingBox::new(x, 10.0, 20.0, 40.0), 0.9, 0i64);
+            tracker.predict();
+            tracker.update(&[det], std::slice::from_ref(&emb));
+            assert!(
+                tracker.tracks.len() <= 40,
+                "tracks grew to {} at frame {f}",
+                tracker.tracks.len()
+            );
+        }
+    }
 }

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -509,4 +509,21 @@ mod tests {
         tracker.update(vec![det(0.0, 0.0, 50.0, 100.0, 0.9)]);
         tracker.update(vec![det(10000.0, 0.0, 50.0, 100.0, 0.9)]);
     }
+
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // A fresh, non-matching object each frame. Tracks must be deleted after
+        // max_age misses, keeping the internal vector bounded by that window.
+        let max_age = 20;
+        let mut tracker = OcSort::new(max_age, 3, 0.3, 3, 0.2);
+        for f in 0..3000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0;
+            let _ = tracker.update(vec![det(x, 10.0, 20.0, 40.0, 0.9)]);
+            assert!(
+                tracker.tracks.len() <= max_age + 5,
+                "storage grew to {} at frame {f}",
+                tracker.tracks.len()
+            );
+        }
+    }
 }

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -434,4 +434,21 @@ mod tests {
         let tracks2 = tracker.update(det2);
         assert_eq!(tracks2[0].track_id, 2);
     }
+
+    #[test]
+    fn storage_stays_bounded_under_churn() {
+        // A fresh, non-matching object each frame. Tracks must be deleted after
+        // max_age misses, keeping the internal vector bounded by that window.
+        let max_age = 20;
+        let mut tracker = Sort::new(max_age, 3, 0.3);
+        for f in 0..3000 {
+            let x = 5.0 + (f % 100) as f32 * 40.0;
+            let _ = tracker.update(vec![([x, 10.0, 20.0, 40.0], 0.9, 0)]);
+            assert!(
+                tracker.tracks.len() <= max_age + 5,
+                "storage grew to {} at frame {f}",
+                tracker.tracks.len()
+            );
+        }
+    }
 }


### PR DESCRIPTION
Every per-track buffer is bounded. The appearance gallery drains past `nn_budget` and keeps only active track ids, `pending_features` is flushed every frame so it cannot grow on a lost track, the observation history is capped, and every tracker prunes deleted tracks each frame. No unbounded growth was found. A long-run churn test for each tracker (SORT, ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, BoT-SORT) that feeds thousands of frames of non-matching detections and asserts the internal storage stays bounded by the buffer or `max_age` window. An id-uniqueness test for ByteTrack across many frames with several persistent objects.

