### PR TITLE
feat(params): unified parameter structs with shared CommonParams

### DIFF
--- a/book/src/parameters.md
+++ b/book/src/parameters.md
@@ -1,8 +1,22 @@
 # Parameters
 
 The parameters are identical across Python and Rust. In Python they are keyword arguments to the
-tracker class; in Rust they are positional arguments to `Tracker::new(...)`. Each tracker's chapter
-documents its own parameters and tuning advice:
+tracker class. In Rust they are positional arguments to `Tracker::new(...)`, or fields on a params
+struct passed to `Tracker::from_params(...)`.
+
+Two settings recur in almost every tracker. How many frames a lost track survives before it is
+dropped, called `max_age` in most trackers and `track_buffer` in ByteTrack and BoT-SORT. And how
+many matched frames in a row confirm a new track, called `min_hits` in most and `n_init` in
+DeepSORT. In Rust these two live in `CommonParams`, which each tracker's params struct embeds as
+`common`.
+
+IoU thresholds come in two opposite flavors. A minimum IoU (`iou_threshold`, higher is stricter) in
+SORT, OC-SORT, and Deep OC-SORT. And a maximum IoU distance of one minus IoU (`match_thresh`,
+`max_iou_distance`, lower is stricter) in ByteTrack, BoT-SORT, and DeepSORT. The full table with a
+plain description of every parameter is on the
+[documentation site](https://onuralpszr.github.io/trackforge/parameters.html).
+
+Each tracker's chapter documents its own parameters and tuning advice:
 
 - [SORT parameters](./trackers/sort.md#parameters)
 - [ByteTrack parameters](./trackers/byte_track.md#parameters)

--- a/book/src/trackers/botsort.md
+++ b/book/src/trackers/botsort.md
@@ -37,6 +37,7 @@ for track_id, tlwh, score, class_id in tracks:
 | `track_buffer`      | 30      | Frames a lost track is kept alive before removal        |
 | `match_thresh`      | 0.8     | Maximum cost for a first-stage (high-confidence) match  |
 | `det_thresh`        | 0.6     | Minimum score to start a new track                      |
+| `second_match_thresh` | 0.5   | Stage-2 match cutoff for recovering low-confidence detections |
 | `proximity_thresh`  | 0.5     | IoU-distance gate above which appearance is ignored     |
 | `appearance_thresh` | 0.25    | Cosine-distance gate above which appearance is ignored  |
 

--- a/book/src/trackers/byte_track.md
+++ b/book/src/trackers/byte_track.md
@@ -20,8 +20,9 @@ for t in tracks {
 | -------------- | ------- | ------------------------------------------------------------------- |
 | `track_thresh` | 0.5     | Confidence threshold separating high- and low-confidence detections |
 | `track_buffer` | 30      | Frames a lost track is buffered before deletion                     |
-| `match_thresh` | 0.8     | IoU threshold for stage-1 (high-confidence) matching                |
+| `match_thresh` | 0.8     | Stage-1 match cutoff as a maximum IoU distance (lower is stricter)   |
 | `det_thresh`   | 0.6     | Minimum confidence to initialise a new track                        |
+| `second_match_thresh` | 0.5 | Stage-2 match cutoff for recovering low-confidence detections |
 
 **Tuning:** lower `track_thresh` (~0.3) to feed more low-confidence detections into stage two; raise
 `track_buffer` (~60) when the detector drops frames; lower `match_thresh` (~0.7) for fast-moving

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,50 +1,94 @@
 # Parameters
 
-Every tracker exposes the same parameters in Python and Rust. In Python they are keyword
-arguments to the tracker class (`BYTETRACK`, `DEEPSORT`, `OCSORT`, `SORT`); in Rust they are
-positional arguments to `Tracker::new(...)`. The defaults below are identical across both.
+Every tracker takes the same parameters in Python and Rust. In Python they are keyword arguments to the tracker class. In Rust they are positional arguments to `Tracker::new(...)`, or fields on a params struct passed to `Tracker::from_params(...)`. The defaults are identical across both languages.
 
-## ByteTrack
+## Two ideas that show up everywhere
 
-`BYTETRACK(...)` / `ByteTrack::new(track_thresh, track_buffer, match_thresh, det_thresh)`
+Two settings mean the same thing in almost every tracker, even though the names differ.
 
-| Parameter      | Type  | Default | Description                                     |
-| -------------- | ----- | ------- | ----------------------------------------------- |
-| `track_thresh` | float | 0.5     | High confidence detection threshold             |
-| `track_buffer` | int   | 30      | Frames to keep lost tracks alive                |
-| `match_thresh` | float | 0.8     | IoU threshold for matching                      |
-| `det_thresh`   | float | 0.6     | Minimum detection confidence for initialization |
+- Lost track survival. How many frames a track stays alive after it stops matching any detection. If an object is missed or hidden for up to this many frames, the track keeps its id and can be picked back up. Past that it is dropped. Larger rides out longer occlusions but risks handing an old id to a new object. It is called `max_age` in SORT, OC-SORT, DeepSORT, and Deep OC-SORT, and `track_buffer` in ByteTrack and BoT-SORT.
+- Confirmation. How many matched frames in a row a new track needs before it is reported. Larger hides flickering false tracks but delays real ones. It is called `min_hits` in SORT, OC-SORT, and Deep OC-SORT, and `n_init` in DeepSORT. ByteTrack and BoT-SORT confirm on the first high confidence match, so they have no such setting.
 
-## DeepSORT
+In Rust these two live together in `CommonParams { max_age, min_hits }`, which every tracker's params struct embeds as `common`.
 
-`DEEPSORT(...)` / `DeepSort::new(extractor, max_age, n_init, max_iou_distance, max_cosine_distance, nn_budget)`
+## A note on IoU thresholds
 
-| Parameter             | Type  | Default | Description                                      |
-| --------------------- | ----- | ------- | ------------------------------------------------ |
-| `max_age`             | int   | 70      | Max frames to keep a track without detection     |
-| `n_init`              | int   | 3       | Consecutive detections needed to confirm a track |
-| `max_iou_distance`    | float | 0.7     | Max IoU distance for association                 |
-| `max_cosine_distance` | float | 0.2     | Max cosine distance for Re-ID matching           |
-| `nn_budget`           | int   | 100     | Max appearance feature library size per track    |
+IoU thresholds come in two opposite flavors, matching the original papers. Read the description before tuning.
 
-## OC-SORT
-
-`OCSORT(...)` / `OcSort::new(max_age, min_hits, iou_threshold, delta_t, inertia)`
-
-| Parameter       | Type  | Default | Description                                            |
-| --------------- | ----- | ------- | ------------------------------------------------------ |
-| `max_age`       | int   | 30      | Max frames to keep a lost track alive before deletion  |
-| `min_hits`      | int   | 3       | Consecutive matched frames required to confirm a track |
-| `iou_threshold` | float | 0.3     | IoU threshold for matching                             |
-| `delta_t`       | int   | 3       | Observation window (frames) for velocity computation   |
-| `inertia`       | float | 0.2     | Weight for the direction-consistency cost bonus (OCM)  |
+- Minimum IoU. The boxes must overlap by at least this much. Higher is stricter. Used by `iou_threshold` in SORT, OC-SORT, and Deep OC-SORT.
+- Maximum IoU distance. The cost is one minus IoU, and a pair matches only when that cost is at or below the value, so lower is stricter. A value of 0.8 means the boxes only need an IoU of 0.2. Used by `match_thresh` in ByteTrack and BoT-SORT, and `max_iou_distance` in DeepSORT.
 
 ## SORT
 
-`SORT(...)` / `Sort::new(max_age, min_hits, iou_threshold)`
+`SORT(...)` and `Sort::new(max_age, min_hits, iou_threshold)`
 
-| Parameter       | Type  | Default | Description                                  |
-| --------------- | ----- | ------- | -------------------------------------------- |
-| `max_age`       | int   | 1       | Max frames to keep a track without detection |
-| `min_hits`      | int   | 3       | Minimum hits before a track is confirmed     |
-| `iou_threshold` | float | 0.3     | IoU threshold for matching                   |
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `max_age` | int | 1 | Frames a track survives with no matched detection before it is dropped. |
+| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
+| `iou_threshold` | float | 0.3 | Minimum IoU overlap to treat a detection and a track as the same object. Higher is stricter. |
+
+## ByteTrack
+
+`BYTETRACK(...)` and `ByteTrack::new(track_thresh, track_buffer, match_thresh, det_thresh)`
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `track_thresh` | float | 0.5 | Score above which a detection is high confidence and matched first. Lower scores are held for the second pass. |
+| `track_buffer` | int | 30 | Frames a lost track is kept alive so it can be recovered. |
+| `match_thresh` | float | 0.8 | First stage match cutoff as a maximum IoU distance. Lower is stricter. |
+| `det_thresh` | float | 0.6 | Smallest score an unmatched high confidence detection needs to start a new track. |
+| `second_match_thresh` | float | 0.5 | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance. This is ByteTrack's recovery step. |
+
+## OC-SORT
+
+`OCSORT(...)` and `OcSort::new(max_age, min_hits, iou_threshold, delta_t, inertia)`
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `max_age` | int | 30 | Frames a lost track survives before deletion. |
+| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
+| `iou_threshold` | float | 0.3 | Minimum IoU overlap to associate. Higher is stricter. |
+| `delta_t` | int | 3 | How many frames back to look when estimating an object's direction of travel from its real past positions. |
+| `inertia` | float | 0.2 | How strongly that direction of travel is trusted when matching, from zero to one. Zero turns it off. |
+
+## DeepSORT
+
+`DEEPSORT(...)` and `DeepSort::new(extractor, max_age, n_init, max_iou_distance, max_cosine_distance, nn_budget)`
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `max_age` | int | 70 | Frames a track survives with no matched detection before deletion. |
+| `n_init` | int | 3 | Matched frames in a row before a track is confirmed. |
+| `max_iou_distance` | float | 0.7 | IoU fallback match cutoff as a maximum IoU distance. Lower is stricter. |
+| `max_cosine_distance` | float | 0.2 | How different two appearance embeddings may be and still count as the same object. Lower cuts id switches. |
+| `nn_budget` | int | 100 | How many past appearance embeddings to keep per track. When full the oldest is dropped. |
+
+## Deep OC-SORT
+
+`DEEPOCSORT(...)` and `DeepOcSort::new(extractor, max_age, min_hits, iou_threshold, delta_t, inertia, appearance_weight, max_cosine_distance, nn_budget)`
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `max_age` | int | 30 | Frames a lost track survives before deletion. |
+| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
+| `iou_threshold` | float | 0.3 | Minimum IoU overlap to associate. Higher is stricter. |
+| `delta_t` | int | 3 | Frames back to look when estimating direction of travel. |
+| `inertia` | float | 0.2 | How strongly direction of travel is trusted, from zero to one. |
+| `appearance_weight` | float | 0.5 | How much the appearance match counts against the motion match, from zero to one. Zero falls back to plain OC-SORT. |
+| `max_cosine_distance` | float | 0.2 | How different two embeddings may be and still match. Lower is stricter. |
+| `nn_budget` | int | 100 | Past embeddings kept per track. |
+
+## BoT-SORT
+
+`BOTSORT(...)` and `BotSort::new(track_thresh, track_buffer, match_thresh, det_thresh, proximity_thresh, appearance_thresh)`
+
+| Parameter | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `track_thresh` | float | 0.5 | Score above which a detection is high confidence and matched first. |
+| `track_buffer` | int | 30 | Frames a lost track is kept alive. |
+| `match_thresh` | float | 0.8 | First stage match cutoff as a maximum IoU distance. Lower is stricter. |
+| `det_thresh` | float | 0.6 | Smallest score an unmatched high confidence detection needs to start a new track. |
+| `second_match_thresh` | float | 0.5 | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance. |
+| `proximity_thresh` | float | 0.5 | How much boxes must overlap before appearance is allowed to influence the match, a maximum IoU distance. |
+| `appearance_thresh` | float | 0.25 | How close two embeddings must be for Re-ID to help the match, a maximum cosine distance. |

--- a/python/trackforge.pyi
+++ b/python/trackforge.pyi
@@ -35,6 +35,7 @@ class BYTETRACK:
         track_buffer: int = 30,
         match_thresh: float = 0.8,
         det_thresh: float = 0.6,
+        second_match_thresh: float = 0.5,
     ) -> None: ...
     def update(
         self, output_results: List[Tuple[List[float], float, int]]
@@ -245,6 +246,7 @@ class BOTSORT:
         track_buffer: int = 30,
         match_thresh: float = 0.8,
         det_thresh: float = 0.6,
+        second_match_thresh: float = 0.5,
         proximity_thresh: float = 0.5,
         appearance_thresh: float = 0.25,
     ) -> None: ...

--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("README.md")]
 
 use crate::trackers::byte_track::TrackState;
-use crate::trackers::common::{CameraMotion, KalmanTrack};
+use crate::trackers::common::{CameraMotion, CommonParams, KalmanTrack};
 use crate::utils::assignment::{greedy_match, iou_match};
 use crate::utils::features::{cosine_distance, l2_normalize};
 use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
@@ -162,10 +162,66 @@ pub struct BotSort {
     track_thresh: f32,
     match_thresh: f32,
     det_thresh: f32,
+    second_match_thresh: f32,
     proximity_thresh: f32,
     appearance_thresh: f32,
     kalman_filter: KalmanFilter,
     next_id: u64,
+}
+
+/// Settings for [`BotSort`].
+///
+/// BoT-SORT is ByteTrack plus camera motion and an optional appearance term, so its
+/// params look like ByteTrack's plus two Re-ID gates. Shared lifecycle fields live in
+/// [`CommonParams`]; BoT-SORT maps its track buffer onto `common.max_age` and, like
+/// ByteTrack, activates on the first match so `common.min_hits` has no effect. Build
+/// it with [`BotSortParams::default`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BotSortParams {
+    /// Shared lifecycle settings. `common.max_age` is the track buffer length.
+    pub common: CommonParams,
+
+    /// Score above which a detection is treated as high confidence and matched first.
+    pub track_thresh: f32,
+
+    /// First stage match cutoff, a maximum IoU distance of one minus IoU. Lower is
+    /// stricter.
+    pub match_thresh: f32,
+
+    /// Smallest score an unmatched high confidence detection needs to start a new
+    /// track.
+    pub det_thresh: f32,
+
+    /// Second stage match cutoff for recovering objects from low confidence
+    /// detections, a maximum IoU distance. Reference value 0.5.
+    pub second_match_thresh: f32,
+
+    /// How much boxes must overlap before appearance is allowed to influence the
+    /// match, as a maximum IoU distance. If a track and a detection are farther apart
+    /// than this, only motion is used and appearance is ignored.
+    pub proximity_thresh: f32,
+
+    /// How close two appearance embeddings must be for Re-ID to help the match, as a
+    /// maximum cosine distance. Above this the appearance term is dropped and the
+    /// match falls back to motion.
+    pub appearance_thresh: f32,
+}
+
+impl Default for BotSortParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 30,
+                min_hits: 3,
+            },
+            track_thresh: 0.5,
+            match_thresh: 0.8,
+            det_thresh: 0.6,
+            second_match_thresh: 0.5,
+            proximity_thresh: 0.5,
+            appearance_thresh: 0.25,
+        }
+    }
 }
 
 impl BotSort {
@@ -187,16 +243,36 @@ impl BotSort {
         proximity_thresh: f32,
         appearance_thresh: f32,
     ) -> Self {
-        Self {
-            tracked_stracks: Vec::new(),
-            lost_stracks: Vec::new(),
-            frame_id: 0,
-            buffer_size: track_buffer,
+        Self::from_params(BotSortParams {
+            common: CommonParams {
+                max_age: track_buffer,
+                min_hits: 3,
+            },
             track_thresh,
             match_thresh,
             det_thresh,
             proximity_thresh,
             appearance_thresh,
+            ..BotSortParams::default()
+        })
+    }
+
+    /// Create a BoT-SORT tracker from a [`BotSortParams`].
+    ///
+    /// BoT-SORT activates a track on its first high confidence match, so
+    /// `params.common.min_hits` has no effect; only `common.max_age` is used.
+    pub fn from_params(params: BotSortParams) -> Self {
+        Self {
+            tracked_stracks: Vec::new(),
+            lost_stracks: Vec::new(),
+            frame_id: 0,
+            buffer_size: params.common.max_age,
+            track_thresh: params.track_thresh,
+            match_thresh: params.match_thresh,
+            det_thresh: params.det_thresh,
+            second_match_thresh: params.second_match_thresh,
+            proximity_thresh: params.proximity_thresh,
+            appearance_thresh: params.appearance_thresh,
             kalman_filter: KalmanFilter::default(),
             next_id: 1,
         }
@@ -309,7 +385,8 @@ impl BotSort {
             .collect();
         let r_boxes: Vec<[f32; 4]> = r_tracked.iter().map(|&i| pool[i].tlwh).collect();
         let low_boxes: Vec<[f32; 4]> = dets_low.iter().map(|d| d.tlwh).collect();
-        let (matches_low, u_track_low, _) = iou_match(&r_boxes, &low_boxes, 0.5);
+        let (matches_low, u_track_low, _) =
+            iou_match(&r_boxes, &low_boxes, self.second_match_thresh);
 
         // `r_tracked` only holds Tracked-state tracks, so a second-stage match is
         // always a plain update (never a re-activation).
@@ -435,33 +512,45 @@ pub struct PyBotSort {
 #[pymethods]
 impl PyBotSort {
     #[new]
-    #[pyo3(signature = (track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6, proximity_thresh=0.5, appearance_thresh=0.25))]
+    #[pyo3(signature = (track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6, second_match_thresh=0.5, proximity_thresh=0.5, appearance_thresh=0.25))]
     /// Initialize the BoT-SORT tracker.
     ///
     /// Args:
-    ///     track_thresh (float): High/low confidence split. Default: 0.5.
+    ///     track_thresh (float): Score above which a detection is high confidence and
+    ///         matched first. Default: 0.5.
     ///     track_buffer (int): Frames a lost track is kept alive. Default: 30.
-    ///     match_thresh (float): Maximum cost for a first-stage match. Default: 0.8.
-    ///     det_thresh (float): Minimum score to start a new track. Default: 0.6.
-    ///     proximity_thresh (float): IoU-distance gate for appearance. Default: 0.5.
-    ///     appearance_thresh (float): Cosine-distance gate for appearance. Default: 0.25.
+    ///     match_thresh (float): First stage match cutoff as a maximum IoU distance of
+    ///         one minus IoU. Lower is stricter. Default: 0.8.
+    ///     det_thresh (float): Smallest score an unmatched high confidence detection
+    ///         needs to start a new track. Default: 0.6.
+    ///     second_match_thresh (float): Second stage match cutoff for recovering low
+    ///         confidence detections, a maximum IoU distance. Default: 0.5.
+    ///     proximity_thresh (float): How much boxes must overlap before appearance is
+    ///         used, as a maximum IoU distance. Default: 0.5.
+    ///     appearance_thresh (float): How close two embeddings must be for Re-ID to
+    ///         help, as a maximum cosine distance. Default: 0.25.
     fn new(
         track_thresh: f32,
         track_buffer: usize,
         match_thresh: f32,
         det_thresh: f32,
+        second_match_thresh: f32,
         proximity_thresh: f32,
         appearance_thresh: f32,
     ) -> Self {
         Self {
-            inner: BotSort::new(
+            inner: BotSort::from_params(BotSortParams {
+                common: CommonParams {
+                    max_age: track_buffer,
+                    min_hits: 3,
+                },
                 track_thresh,
-                track_buffer,
                 match_thresh,
                 det_thresh,
+                second_match_thresh,
                 proximity_thresh,
                 appearance_thresh,
-            ),
+            }),
         }
     }
 

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("README.md")]
 
-use crate::trackers::common::KalmanTrack;
+use crate::trackers::common::{CommonParams, KalmanTrack};
 use crate::utils::geometry::tlwh_to_xyah;
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
 
@@ -142,8 +142,54 @@ pub struct ByteTrack {
     track_thresh: f32,
     match_thresh: f32,
     det_thresh: f32, // For splitting detections into high/low
+    second_match_thresh: f32,
     kalman_filter: KalmanFilter,
     next_id: u64,
+}
+
+/// Settings for [`ByteTrack`].
+///
+/// The shared lifecycle fields live in [`CommonParams`]; ByteTrack maps its track
+/// buffer onto `common.max_age`. Build it with [`ByteTrackParams::default`], tweak
+/// what you need, then pass it to [`ByteTrack::from_params`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ByteTrackParams {
+    /// Shared lifecycle settings. `common.max_age` is how many frames a lost track is
+    /// kept alive, what ByteTrack calls the track buffer.
+    pub common: CommonParams,
+
+    /// Score above which a detection is treated as high confidence and matched first.
+    /// Detections below it are held back for the second, low confidence pass.
+    pub track_thresh: f32,
+
+    /// First stage match cutoff, given as a maximum IoU distance of one minus IoU. A
+    /// pair matches when its IoU distance is at or below this, so a value of 0.8 means
+    /// the boxes only need an IoU of 0.2. Lower is stricter.
+    pub match_thresh: f32,
+
+    /// Smallest score an unmatched high confidence detection needs to start a brand
+    /// new track. Raising it avoids spawning tracks from weak one-off detections.
+    pub det_thresh: f32,
+
+    /// Second stage match cutoff for recovering objects from low confidence
+    /// detections, again a maximum IoU distance. This is ByteTrack's core recovery
+    /// step, and the reference value is 0.5.
+    pub second_match_thresh: f32,
+}
+
+impl Default for ByteTrackParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 30,
+                min_hits: 3,
+            },
+            track_thresh: 0.5,
+            match_thresh: 0.8,
+            det_thresh: 0.6,
+            second_match_thresh: 0.5,
+        }
+    }
 }
 
 impl ByteTrack {
@@ -156,14 +202,32 @@ impl ByteTrack {
     /// * `match_thresh` - IoU threshold for matching (e.g., 0.8).
     /// * `det_thresh` - Threshold for initializing a new track (usually same as or slightly lower than track_thresh).
     pub fn new(track_thresh: f32, track_buffer: usize, match_thresh: f32, det_thresh: f32) -> Self {
+        Self::from_params(ByteTrackParams {
+            common: CommonParams {
+                max_age: track_buffer,
+                min_hits: 3,
+            },
+            track_thresh,
+            match_thresh,
+            det_thresh,
+            ..ByteTrackParams::default()
+        })
+    }
+
+    /// Create a ByteTrack tracker from a [`ByteTrackParams`].
+    ///
+    /// ByteTrack activates a track on its first high confidence match, so
+    /// `params.common.min_hits` has no effect here; only `common.max_age` is used.
+    pub fn from_params(params: ByteTrackParams) -> Self {
         Self {
             tracked_stracks: Vec::new(),
             lost_stracks: Vec::new(),
             frame_id: 0,
-            buffer_size: track_buffer, // Simplified usage
-            track_thresh,
-            match_thresh,
-            det_thresh,
+            buffer_size: params.common.max_age,
+            track_thresh: params.track_thresh,
+            match_thresh: params.match_thresh,
+            det_thresh: params.det_thresh,
+            second_match_thresh: params.second_match_thresh,
             kalman_filter: KalmanFilter::default(),
             next_id: 1,
         }
@@ -255,7 +319,7 @@ impl ByteTrack {
         let r_tracked_boxes: Vec<[f32; 4]> = r_tracked_stracks.iter().map(|s| s.tlwh).collect();
         let low_boxes: Vec<[f32; 4]> = detections_low.iter().map(|s| s.tlwh).collect();
         let (matches, u_track_second, _) =
-            crate::utils::assignment::iou_match(&r_tracked_boxes, &low_boxes, 0.5);
+            crate::utils::assignment::iou_match(&r_tracked_boxes, &low_boxes, self.second_match_thresh);
 
         for (itrack, idet) in matches {
             let track = &mut r_tracked_stracks[itrack];
@@ -337,17 +401,39 @@ pub struct PyByteTrack {
 #[pymethods]
 impl PyByteTrack {
     #[new]
-    #[pyo3(signature = (track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6))]
+    #[pyo3(signature = (track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thresh=0.6, second_match_thresh=0.5))]
     /// Initialize the ByteTrack tracker.
     ///
     /// Args:
-    ///     track_thresh (float, optional): High confidence detection threshold. Defaults to 0.5.
-    ///     track_buffer (int, optional): Number of frames to keep lost tracks alive. Defaults to 30.
-    ///     match_thresh (float, optional): IoU matching threshold. Defaults to 0.8.
-    ///     det_thresh (float, optional): Initialization threshold. Defaults to 0.6.
-    fn new(track_thresh: f32, track_buffer: usize, match_thresh: f32, det_thresh: f32) -> Self {
+    ///     track_thresh (float, optional): Score above which a detection is high
+    ///         confidence and matched first. Defaults to 0.5.
+    ///     track_buffer (int, optional): Frames a lost track is kept alive so it can
+    ///         be recovered. Defaults to 30.
+    ///     match_thresh (float, optional): First stage match cutoff as a maximum IoU
+    ///         distance of one minus IoU. Lower is stricter. Defaults to 0.8.
+    ///     det_thresh (float, optional): Smallest score an unmatched high confidence
+    ///         detection needs to start a new track. Defaults to 0.6.
+    ///     second_match_thresh (float, optional): Second stage match cutoff for
+    ///         recovering low confidence detections, a maximum IoU distance.
+    ///         Defaults to 0.5.
+    fn new(
+        track_thresh: f32,
+        track_buffer: usize,
+        match_thresh: f32,
+        det_thresh: f32,
+        second_match_thresh: f32,
+    ) -> Self {
         Self {
-            inner: ByteTrack::new(track_thresh, track_buffer, match_thresh, det_thresh),
+            inner: ByteTrack::from_params(ByteTrackParams {
+                common: CommonParams {
+                    max_age: track_buffer,
+                    min_hits: 3,
+                },
+                track_thresh,
+                match_thresh,
+                det_thresh,
+                second_match_thresh,
+            }),
         }
     }
 
@@ -547,5 +633,39 @@ mod tests {
             };
             assert_eq!(ids.len(), unique, "duplicate id in frame {f}: {ids:?}");
         }
+    }
+
+    #[test]
+    fn from_params_default_matches_new() {
+        // The params path with defaults must behave exactly like the positional new.
+        let mut a = ByteTrack::from_params(ByteTrackParams::default());
+        let mut b = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        let d = vec![([10.0, 10.0, 50.0, 100.0], 0.9, 0)];
+        let ra = a.update(d.clone());
+        let rb = b.update(d);
+        assert_eq!(ra.len(), rb.len());
+        assert_eq!(ra[0].track_id, rb[0].track_id);
+        assert_eq!(ra[0].tlwh, rb[0].tlwh);
+    }
+
+    #[test]
+    fn second_match_thresh_controls_low_stage_recovery() {
+        let high = ([10.0, 10.0, 50.0, 50.0], 0.9, 0);
+        let low = ([12.0, 12.0, 50.0, 50.0], 0.4, 0); // below track_thresh, second stage
+
+        // Impossible second stage: the low-confidence detection cannot be recovered.
+        let mut strict = ByteTrack::from_params(ByteTrackParams {
+            second_match_thresh: 0.0,
+            ..ByteTrackParams::default()
+        });
+        strict.update(vec![high]);
+        assert!(strict.update(vec![low]).is_empty());
+
+        // Default second stage recovers the same object and keeps its id.
+        let mut lax = ByteTrack::from_params(ByteTrackParams::default());
+        let id = lax.update(vec![high])[0].track_id;
+        let out = lax.update(vec![low]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].track_id, id);
     }
 }

--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -8,9 +8,11 @@
 pub mod association;
 pub mod cmc;
 pub mod obs_track;
+pub mod params;
 
 pub use cmc::CameraMotion;
 pub use obs_track::ObsTrack;
+pub use params::CommonParams;
 
 use crate::utils::geometry::xyah_to_tlwh;
 

--- a/src/trackers/common/params.rs
+++ b/src/trackers/common/params.rs
@@ -1,0 +1,43 @@
+//! Parameters shared by every tracker.
+//!
+//! These two settings control the track lifecycle and mean the same thing in every
+//! tracker, so they live here once instead of being repeated under different names
+//! (`max_age` vs `track_buffer`, `min_hits` vs `n_init`). Each tracker keeps its own
+//! specific settings in its own params struct and embeds a [`CommonParams`] for these.
+
+/// Lifecycle settings common to all trackers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommonParams {
+    /// How many frames a track stays alive after it stops matching any detection.
+    ///
+    /// If an object is missed or hidden for up to this many frames, the track keeps
+    /// its id and can be picked back up when the object returns. Past this the track
+    /// is dropped. Larger values ride out longer occlusions but risk keeping stale
+    /// tracks and handing an old id to a different object. Some trackers call this
+    /// the track buffer; it is the same thing.
+    pub max_age: usize,
+
+    /// How many matched frames in a row a new track needs before it is confirmed and
+    /// returned to the caller.
+    ///
+    /// Larger values suppress flickering false tracks from one-off detections but
+    /// delay when a real object first shows up in the output. Some trackers call this
+    /// `n_init`; it is the same thing.
+    pub min_hits: usize,
+}
+
+impl Default for CommonParams {
+    fn default() -> Self {
+        Self {
+            max_age: 30,
+            min_hits: 3,
+        }
+    }
+}
+
+impl CommonParams {
+    /// Build the common lifecycle settings directly.
+    pub fn new(max_age: usize, min_hits: usize) -> Self {
+        Self { max_age, min_hits }
+    }
+}

--- a/src/trackers/deep_ocsort/mod.rs
+++ b/src/trackers/deep_ocsort/mod.rs
@@ -15,6 +15,63 @@ pub mod python;
 pub use crate::trackers::common::ObsTrack as DeepOcSortTrack;
 pub use tracker::DeepOcSortTracker;
 
+use crate::trackers::common::CommonParams;
+
+/// Settings for `DeepOcSort`.
+///
+/// Shared lifecycle fields live in [`CommonParams`]; the rest are Deep OC-SORT
+/// specific. This is OC-SORT plus an appearance term, so it carries the OC-SORT
+/// motion fields and the Re-ID fields together. Build it with
+/// [`DeepOcSortParams::default`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DeepOcSortParams {
+    /// Shared lifecycle settings, `max_age` and `min_hits`.
+    pub common: CommonParams,
+
+    /// Smallest IoU overlap that still counts as the same object. This is a minimum
+    /// IoU, so higher is stricter.
+    pub iou_threshold: f32,
+
+    /// How many frames back the tracker looks to estimate an object's direction of
+    /// travel from its real past positions. Larger is steadier but slower to react to
+    /// turns.
+    pub delta_t: usize,
+
+    /// How strongly a track's recent direction of travel is trusted when matching, in
+    /// the range zero to one. Zero turns the direction term off.
+    pub inertia: f32,
+
+    /// How much the appearance match counts against the motion match when scoring a
+    /// pair, in the range zero to one. Zero ignores appearance and falls back to plain
+    /// OC-SORT; higher leans on Re-ID to hold ids through occlusion.
+    pub appearance_weight: f32,
+
+    /// How different two appearance embeddings may be and still count as the same
+    /// object, as cosine distance. Lower demands a closer appearance match.
+    pub max_cosine_distance: f32,
+
+    /// How many past appearance embeddings to keep per track for Re-ID. When the
+    /// gallery is full the oldest is dropped.
+    pub nn_budget: usize,
+}
+
+impl Default for DeepOcSortParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 30,
+                min_hits: 3,
+            },
+            iou_threshold: 0.3,
+            delta_t: 3,
+            inertia: 0.2,
+            appearance_weight: 0.5,
+            max_cosine_distance: 0.2,
+            nn_budget: 100,
+        }
+    }
+}
+
 #[cfg(any(test, feature = "reid-model"))]
 use crate::trackers::common::CameraMotion;
 #[cfg(any(test, feature = "python", feature = "reid-model"))]
@@ -92,15 +149,31 @@ impl<E: AppearanceExtractor> DeepOcSort<E> {
         max_cosine_distance: f32,
         nn_budget: usize,
     ) -> Self {
+        Self::from_params(
+            extractor,
+            DeepOcSortParams {
+                common: CommonParams::new(max_age, min_hits),
+                iou_threshold,
+                delta_t,
+                inertia,
+                appearance_weight,
+                max_cosine_distance,
+                nn_budget,
+            },
+        )
+    }
+
+    /// Create a Deep OC-SORT tracker from an extractor and a [`DeepOcSortParams`].
+    pub fn from_params(extractor: E, params: DeepOcSortParams) -> Self {
         let tracker = build_tracker(
-            max_age,
-            min_hits,
-            iou_threshold,
-            delta_t,
-            inertia,
-            appearance_weight,
-            max_cosine_distance,
-            nn_budget,
+            params.common.max_age,
+            params.common.min_hits,
+            params.iou_threshold,
+            params.delta_t,
+            params.inertia,
+            params.appearance_weight,
+            params.max_cosine_distance,
+            params.nn_budget,
         );
         Self { extractor, tracker }
     }

--- a/src/trackers/deepsort/mod.rs
+++ b/src/trackers/deepsort/mod.rs
@@ -13,6 +13,48 @@ pub use nn_matching::{Metric, NearestNeighborDistanceMetric};
 pub use track::{Track, TrackState};
 pub use tracker::DeepSortTracker;
 
+use crate::trackers::common::CommonParams;
+
+/// Settings for `DeepSort`.
+///
+/// Shared lifecycle fields live in [`CommonParams`]; DeepSORT reads its confirmation
+/// count from `common.min_hits`, what it calls `n_init`. The rest are DeepSORT
+/// specific. Build it with [`DeepSortParams::default`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DeepSortParams {
+    /// Shared lifecycle settings. `common.min_hits` is DeepSORT's `n_init`.
+    pub common: CommonParams,
+
+    /// Match cutoff for the IoU fallback stage, given as a maximum IoU distance of one
+    /// minus IoU. A pair matches when its IoU distance is at or below this, so 0.7
+    /// means the boxes only need an IoU of 0.3. Lower is stricter.
+    pub max_iou_distance: f32,
+
+    /// How different two appearance embeddings may be and still count as the same
+    /// object, measured as cosine distance from zero to two. Lower demands a closer
+    /// appearance match and cuts id switches, at the cost of more lost tracks.
+    pub max_cosine_distance: f32,
+
+    /// How many past appearance embeddings to keep per track for Re-ID. When the
+    /// gallery is full the oldest is dropped. Larger remembers more of how the object
+    /// looked over time but uses more memory and compute.
+    pub nn_budget: usize,
+}
+
+impl Default for DeepSortParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 70,
+                min_hits: 3,
+            },
+            max_iou_distance: 0.7,
+            max_cosine_distance: 0.2,
+            nn_budget: 100,
+        }
+    }
+}
+
 #[cfg(feature = "reid-model")]
 use crate::traits::AppearanceExtractor;
 #[cfg(feature = "reid-model")]
@@ -65,12 +107,28 @@ impl<E: AppearanceExtractor> DeepSort<E> {
         max_cosine_distance: f32,
         nn_budget: usize,
     ) -> Self {
+        Self::from_params(
+            extractor,
+            DeepSortParams {
+                common: CommonParams {
+                    max_age,
+                    min_hits: n_init,
+                },
+                max_iou_distance,
+                max_cosine_distance,
+                nn_budget,
+            },
+        )
+    }
+
+    /// Create a Deep SORT tracker from an extractor and a [`DeepSortParams`].
+    pub fn from_params(extractor: E, params: DeepSortParams) -> Self {
         let tracker = build_tracker(
-            max_age,
-            n_init,
-            max_iou_distance,
-            max_cosine_distance,
-            nn_budget,
+            params.common.max_age,
+            params.common.min_hits,
+            params.max_iou_distance,
+            params.max_cosine_distance,
+            params.nn_budget,
         );
 
         Self { extractor, tracker }

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -1,10 +1,49 @@
 #![doc = include_str!("README.md")]
 
 use crate::trackers::common::association::{last_observation_rematch, ocm_angle_bonus};
-use crate::trackers::common::{ObsTrack, TrackState};
+use crate::trackers::common::{CommonParams, ObsTrack, TrackState};
 use crate::utils::assignment::greedy_match;
 use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
 use std::collections::HashSet;
+
+/// Settings for [`OcSort`].
+///
+/// Shared lifecycle fields live in [`CommonParams`]; the fields below are specific to
+/// OC-SORT. Build it with [`OcSortParams::default`] and pass it to
+/// [`OcSort::from_params`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OcSortParams {
+    /// Shared lifecycle settings, `max_age` and `min_hits`.
+    pub common: CommonParams,
+
+    /// Smallest IoU overlap that still counts as the same object. This is a minimum
+    /// IoU, so higher is stricter.
+    pub iou_threshold: f32,
+
+    /// How many frames back OC-SORT looks to estimate an object's direction of travel
+    /// from its real past positions. A larger window gives a steadier direction but
+    /// reacts more slowly when the object turns.
+    pub delta_t: usize,
+
+    /// How strongly a track's recent direction of travel is trusted when matching,
+    /// in the range zero to one. Higher leans on motion direction to keep ids through
+    /// brief occlusions; zero turns the direction term off.
+    pub inertia: f32,
+}
+
+impl Default for OcSortParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 30,
+                min_hits: 3,
+            },
+            iou_threshold: 0.3,
+            delta_t: 3,
+            inertia: 0.2,
+        }
+    }
+}
 
 /// Track lifecycle state for OC-SORT.
 ///
@@ -83,13 +122,23 @@ impl OcSort {
         delta_t: usize,
         inertia: f32,
     ) -> Self {
-        Self {
-            tracks: Vec::new(),
-            max_age,
-            min_hits,
+        Self::from_params(OcSortParams {
+            common: CommonParams::new(max_age, min_hits),
             iou_threshold,
             delta_t,
-            inertia: inertia.clamp(0.0, 1.0),
+            inertia,
+        })
+    }
+
+    /// Create an OC-SORT tracker from an [`OcSortParams`].
+    pub fn from_params(params: OcSortParams) -> Self {
+        Self {
+            tracks: Vec::new(),
+            max_age: params.common.max_age,
+            min_hits: params.common.min_hits,
+            iou_threshold: params.iou_threshold,
+            delta_t: params.delta_t,
+            inertia: params.inertia.clamp(0.0, 1.0),
             kf: crate::utils::kalman::KalmanFilter::default(),
             next_id: 1,
             frame_count: 0,

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -1,8 +1,37 @@
 #![doc = include_str!("README.md")]
 
-use crate::trackers::common::{KalmanTrack, TrackState};
+use crate::trackers::common::{CommonParams, KalmanTrack, TrackState};
 use crate::utils::geometry::tlwh_to_xyah;
 use crate::utils::kalman::KalmanFilter;
+
+/// Settings for [`Sort`].
+///
+/// The shared lifecycle fields live in [`CommonParams`]; the field below is specific
+/// to SORT. Build it with [`SortParams::default`] and tweak what you need, then pass
+/// it to [`Sort::from_params`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SortParams {
+    /// Shared lifecycle settings, `max_age` and `min_hits`.
+    pub common: CommonParams,
+
+    /// Smallest IoU overlap that still counts as the same object between a track and
+    /// a detection. This is a minimum IoU, so higher is stricter and separates
+    /// touching objects more readily, while lower tolerates loose boxes but risks
+    /// swapping ids.
+    pub iou_threshold: f32,
+}
+
+impl Default for SortParams {
+    fn default() -> Self {
+        Self {
+            common: CommonParams {
+                max_age: 1,
+                min_hits: 3,
+            },
+            iou_threshold: 0.3,
+        }
+    }
+}
 
 /// Track state enumeration for SORT.
 ///
@@ -137,11 +166,19 @@ impl Sort {
     /// * `min_hits` - Minimum consecutive hits before track is confirmed (default: 3).
     /// * `iou_threshold` - Minimum IoU for matching detection to track (default: 0.3).
     pub fn new(max_age: usize, min_hits: usize, iou_threshold: f32) -> Self {
+        Self::from_params(SortParams {
+            common: CommonParams::new(max_age, min_hits),
+            iou_threshold,
+        })
+    }
+
+    /// Create a SORT tracker from a [`SortParams`].
+    pub fn from_params(params: SortParams) -> Self {
         Self {
             tracks: Vec::new(),
-            max_age,
-            min_hits,
-            iou_threshold,
+            max_age: params.common.max_age,
+            min_hits: params.common.min_hits,
+            iou_threshold: params.iou_threshold,
             kalman_filter: KalmanFilter::default(),
             next_id: 1,
         }


### PR DESCRIPTION
## What this adds

A unified parameter system with a clean split between shared and tracker specific settings.

- `CommonParams { max_age, min_hits }` holds the two lifecycle settings every tracker shares. Trackers that name them differently (`track_buffer`, `n_init`) now map onto these.
- One params struct per tracker (`SortParams`, `ByteTrackParams`, `OcSortParams`, `DeepSortParams`, `DeepOcSortParams`, `BotSortParams`) embeds `common` and holds its own fields with paper faithful names, each with a plain-language doc.
- Every tracker gains `from_params`. The positional `new` and the Python kwargs stay as wrappers.

```rust
let mut p = ByteTrackParams::default();
p.common.max_age = 50;
p.match_thresh = 0.9;
let t = ByteTrack::from_params(p);
```

## New knob

ByteTrack and BoT-SORT had their second stage IoU distance hardcoded at 0.5. It is now `second_match_thresh`, exposed in Rust and Python, defaulting to 0.5.

## Docs

The parameters page is rewritten with a plain description of every parameter, the two shared concepts, and the two opposite IoU threshold conventions (minimum IoU vs maximum IoU distance) so tuning is not a guess.
