### PR TITLE
style: fix cargo fmt and prettier on main

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -22,73 +22,73 @@ IoU thresholds come in two opposite flavors, matching the original papers. Read 
 
 `SORT(...)` and `Sort::new(max_age, min_hits, iou_threshold)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `max_age` | int | 1 | Frames a track survives with no matched detection before it is dropped. |
-| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
-| `iou_threshold` | float | 0.3 | Minimum IoU overlap to treat a detection and a track as the same object. Higher is stricter. |
+| Parameter       | Type  | Default | Meaning                                                                                      |
+| --------------- | ----- | ------- | -------------------------------------------------------------------------------------------- |
+| `max_age`       | int   | 1       | Frames a track survives with no matched detection before it is dropped.                      |
+| `min_hits`      | int   | 3       | Matched frames in a row before a track is reported.                                          |
+| `iou_threshold` | float | 0.3     | Minimum IoU overlap to treat a detection and a track as the same object. Higher is stricter. |
 
 ## ByteTrack
 
 `BYTETRACK(...)` and `ByteTrack::new(track_thresh, track_buffer, match_thresh, det_thresh)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `track_thresh` | float | 0.5 | Score above which a detection is high confidence and matched first. Lower scores are held for the second pass. |
-| `track_buffer` | int | 30 | Frames a lost track is kept alive so it can be recovered. |
-| `match_thresh` | float | 0.8 | First stage match cutoff as a maximum IoU distance. Lower is stricter. |
-| `det_thresh` | float | 0.6 | Smallest score an unmatched high confidence detection needs to start a new track. |
-| `second_match_thresh` | float | 0.5 | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance. This is ByteTrack's recovery step. |
+| Parameter             | Type  | Default | Meaning                                                                                                                        |
+| --------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `track_thresh`        | float | 0.5     | Score above which a detection is high confidence and matched first. Lower scores are held for the second pass.                 |
+| `track_buffer`        | int   | 30      | Frames a lost track is kept alive so it can be recovered.                                                                      |
+| `match_thresh`        | float | 0.8     | First stage match cutoff as a maximum IoU distance. Lower is stricter.                                                         |
+| `det_thresh`          | float | 0.6     | Smallest score an unmatched high confidence detection needs to start a new track.                                              |
+| `second_match_thresh` | float | 0.5     | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance. This is ByteTrack's recovery step. |
 
 ## OC-SORT
 
 `OCSORT(...)` and `OcSort::new(max_age, min_hits, iou_threshold, delta_t, inertia)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `max_age` | int | 30 | Frames a lost track survives before deletion. |
-| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
-| `iou_threshold` | float | 0.3 | Minimum IoU overlap to associate. Higher is stricter. |
-| `delta_t` | int | 3 | How many frames back to look when estimating an object's direction of travel from its real past positions. |
-| `inertia` | float | 0.2 | How strongly that direction of travel is trusted when matching, from zero to one. Zero turns it off. |
+| Parameter       | Type  | Default | Meaning                                                                                                    |
+| --------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `max_age`       | int   | 30      | Frames a lost track survives before deletion.                                                              |
+| `min_hits`      | int   | 3       | Matched frames in a row before a track is reported.                                                        |
+| `iou_threshold` | float | 0.3     | Minimum IoU overlap to associate. Higher is stricter.                                                      |
+| `delta_t`       | int   | 3       | How many frames back to look when estimating an object's direction of travel from its real past positions. |
+| `inertia`       | float | 0.2     | How strongly that direction of travel is trusted when matching, from zero to one. Zero turns it off.       |
 
 ## DeepSORT
 
 `DEEPSORT(...)` and `DeepSort::new(extractor, max_age, n_init, max_iou_distance, max_cosine_distance, nn_budget)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `max_age` | int | 70 | Frames a track survives with no matched detection before deletion. |
-| `n_init` | int | 3 | Matched frames in a row before a track is confirmed. |
-| `max_iou_distance` | float | 0.7 | IoU fallback match cutoff as a maximum IoU distance. Lower is stricter. |
-| `max_cosine_distance` | float | 0.2 | How different two appearance embeddings may be and still count as the same object. Lower cuts id switches. |
-| `nn_budget` | int | 100 | How many past appearance embeddings to keep per track. When full the oldest is dropped. |
+| Parameter             | Type  | Default | Meaning                                                                                                    |
+| --------------------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `max_age`             | int   | 70      | Frames a track survives with no matched detection before deletion.                                         |
+| `n_init`              | int   | 3       | Matched frames in a row before a track is confirmed.                                                       |
+| `max_iou_distance`    | float | 0.7     | IoU fallback match cutoff as a maximum IoU distance. Lower is stricter.                                    |
+| `max_cosine_distance` | float | 0.2     | How different two appearance embeddings may be and still count as the same object. Lower cuts id switches. |
+| `nn_budget`           | int   | 100     | How many past appearance embeddings to keep per track. When full the oldest is dropped.                    |
 
 ## Deep OC-SORT
 
 `DEEPOCSORT(...)` and `DeepOcSort::new(extractor, max_age, min_hits, iou_threshold, delta_t, inertia, appearance_weight, max_cosine_distance, nn_budget)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `max_age` | int | 30 | Frames a lost track survives before deletion. |
-| `min_hits` | int | 3 | Matched frames in a row before a track is reported. |
-| `iou_threshold` | float | 0.3 | Minimum IoU overlap to associate. Higher is stricter. |
-| `delta_t` | int | 3 | Frames back to look when estimating direction of travel. |
-| `inertia` | float | 0.2 | How strongly direction of travel is trusted, from zero to one. |
-| `appearance_weight` | float | 0.5 | How much the appearance match counts against the motion match, from zero to one. Zero falls back to plain OC-SORT. |
-| `max_cosine_distance` | float | 0.2 | How different two embeddings may be and still match. Lower is stricter. |
-| `nn_budget` | int | 100 | Past embeddings kept per track. |
+| Parameter             | Type  | Default | Meaning                                                                                                            |
+| --------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `max_age`             | int   | 30      | Frames a lost track survives before deletion.                                                                      |
+| `min_hits`            | int   | 3       | Matched frames in a row before a track is reported.                                                                |
+| `iou_threshold`       | float | 0.3     | Minimum IoU overlap to associate. Higher is stricter.                                                              |
+| `delta_t`             | int   | 3       | Frames back to look when estimating direction of travel.                                                           |
+| `inertia`             | float | 0.2     | How strongly direction of travel is trusted, from zero to one.                                                     |
+| `appearance_weight`   | float | 0.5     | How much the appearance match counts against the motion match, from zero to one. Zero falls back to plain OC-SORT. |
+| `max_cosine_distance` | float | 0.2     | How different two embeddings may be and still match. Lower is stricter.                                            |
+| `nn_budget`           | int   | 100     | Past embeddings kept per track.                                                                                    |
 
 ## BoT-SORT
 
 `BOTSORT(...)` and `BotSort::new(track_thresh, track_buffer, match_thresh, det_thresh, proximity_thresh, appearance_thresh)`
 
-| Parameter | Type | Default | Meaning |
-| --- | --- | --- | --- |
-| `track_thresh` | float | 0.5 | Score above which a detection is high confidence and matched first. |
-| `track_buffer` | int | 30 | Frames a lost track is kept alive. |
-| `match_thresh` | float | 0.8 | First stage match cutoff as a maximum IoU distance. Lower is stricter. |
-| `det_thresh` | float | 0.6 | Smallest score an unmatched high confidence detection needs to start a new track. |
-| `second_match_thresh` | float | 0.5 | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance. |
-| `proximity_thresh` | float | 0.5 | How much boxes must overlap before appearance is allowed to influence the match, a maximum IoU distance. |
-| `appearance_thresh` | float | 0.25 | How close two embeddings must be for Re-ID to help the match, a maximum cosine distance. |
+| Parameter             | Type  | Default | Meaning                                                                                                  |
+| --------------------- | ----- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `track_thresh`        | float | 0.5     | Score above which a detection is high confidence and matched first.                                      |
+| `track_buffer`        | int   | 30      | Frames a lost track is kept alive.                                                                       |
+| `match_thresh`        | float | 0.8     | First stage match cutoff as a maximum IoU distance. Lower is stricter.                                   |
+| `det_thresh`          | float | 0.6     | Smallest score an unmatched high confidence detection needs to start a new track.                        |
+| `second_match_thresh` | float | 0.5     | Second stage match cutoff for recovering low confidence detections, a maximum IoU distance.              |
+| `proximity_thresh`    | float | 0.5     | How much boxes must overlap before appearance is allowed to influence the match, a maximum IoU distance. |
+| `appearance_thresh`   | float | 0.25    | How close two embeddings must be for Re-ID to help the match, a maximum cosine distance.                 |

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -318,8 +318,11 @@ impl ByteTrack {
         // Second matching: low-confidence detections against still-tracked leftovers.
         let r_tracked_boxes: Vec<[f32; 4]> = r_tracked_stracks.iter().map(|s| s.tlwh).collect();
         let low_boxes: Vec<[f32; 4]> = detections_low.iter().map(|s| s.tlwh).collect();
-        let (matches, u_track_second, _) =
-            crate::utils::assignment::iou_match(&r_tracked_boxes, &low_boxes, self.second_match_thresh);
+        let (matches, u_track_second, _) = crate::utils::assignment::iou_match(
+            &r_tracked_boxes,
+            &low_boxes,
+            self.second_match_thresh,
+        );
 
         for (itrack, idet) in matches {
             let track = &mut r_tracked_stracks[itrack];


### PR DESCRIPTION
Formatting fix for the parameter system merge. Applies cargo fmt to the ByteTrack second stage call and prettier to the parameters doc table, so the Lint and autofix.ci checks pass.