### PR TITLE
refactor(cascade): share the two-stage cascade between ByteTrack and BoT-SORT

### DIFF
--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -1,8 +1,8 @@
 #![doc = include_str!("README.md")]
 
 use crate::trackers::byte_track::TrackState;
+use crate::trackers::common::byte_cascade::{self, CascadeDet, CascadeTrack};
 use crate::trackers::common::{CameraMotion, CommonParams, KalmanTrack};
-use crate::utils::assignment::{greedy_match, iou_match};
 use crate::utils::features::{cosine_distance, l2_normalize};
 use crate::utils::geometry::{iou_batch, tlwh_to_xyah};
 use crate::utils::kalman::KalmanFilter;
@@ -11,7 +11,7 @@ use crate::utils::kalman::KalmanFilter;
 const FEATURE_MOMENTUM: f32 = 0.9;
 
 /// A detection with an optional appearance embedding.
-struct Detection {
+pub(crate) struct Detection {
     tlwh: [f32; 4],
     score: f32,
     class_id: i64,
@@ -128,6 +128,46 @@ impl BotTrack {
                 *sf = l2_normalize(sf);
             }
         }
+    }
+}
+
+impl CascadeDet for Detection {
+    fn det_box(&self) -> [f32; 4] {
+        self.tlwh
+    }
+    fn det_score(&self) -> f32 {
+        self.score
+    }
+}
+
+impl CascadeTrack for BotTrack {
+    type Det = Detection;
+
+    fn is_tracked(&self) -> bool {
+        self.state == TrackState::Tracked
+    }
+    fn is_lost(&self) -> bool {
+        self.state == TrackState::Lost
+    }
+    fn set_lost(&mut self) {
+        self.state = TrackState::Lost;
+    }
+    fn cascade_frame_id(&self) -> usize {
+        self.frame_id
+    }
+    fn cascade_tlwh(&self) -> [f32; 4] {
+        self.tlwh
+    }
+    fn update_matched(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+        self.update(det, frame_id, kf);
+    }
+    fn reactivate_matched(&mut self, det: &Detection, frame_id: usize, kf: &KalmanFilter) {
+        self.re_activate(det, frame_id, kf);
+    }
+    fn spawn(det: &Detection, frame_id: usize, track_id: u64, kf: &KalmanFilter) -> Self {
+        let mut track = BotTrack::from_detection(det, kf);
+        track.activate(frame_id, track_id);
+        track
     }
 }
 
@@ -348,89 +388,29 @@ impl BotSort {
         pool.append(&mut tracked);
         pool.append(&mut self.lost_stracks);
 
-        let mut activated: Vec<BotTrack> = Vec::new();
-        let mut refind: Vec<BotTrack> = Vec::new();
-        let mut lost: Vec<BotTrack> = Vec::new();
+        // Stage-one cost is the appearance-fused cost, which reduces to the plain IoU
+        // distance when no embeddings are present. The cascade guards the empty case.
+        let cost = self.fused_cost(&pool, &dets_high, use_reid);
 
-        // Guard the empty case: greedy_match on an empty matrix cannot report the
-        // unmatched detections, so a first frame (no tracks) would drop them.
-        let (matches, u_track, u_det_high) = if pool.is_empty() || dets_high.is_empty() {
-            (
-                Vec::new(),
-                (0..pool.len()).collect::<Vec<_>>(),
-                (0..dets_high.len()).collect::<Vec<_>>(),
-            )
-        } else {
-            let cost = self.fused_cost(&pool, &dets_high, use_reid);
-            greedy_match(&cost, self.match_thresh)
-        };
-
-        for (itrack, idet) in matches {
-            let det = &dets_high[idet];
-            if pool[itrack].state == TrackState::Tracked {
-                pool[itrack].update(det, self.frame_id, &self.kalman_filter);
-                activated.push(pool[itrack].clone());
-            } else {
-                pool[itrack].re_activate(det, self.frame_id, &self.kalman_filter);
-                refind.push(pool[itrack].clone());
-            }
-        }
-
-        // Second stage: low-confidence detections against still-Tracked leftovers,
-        // matched on IoU only.
-        let r_tracked: Vec<usize> = u_track
-            .iter()
-            .copied()
-            .filter(|&i| pool[i].state == TrackState::Tracked)
-            .collect();
-        let r_boxes: Vec<[f32; 4]> = r_tracked.iter().map(|&i| pool[i].tlwh).collect();
-        let low_boxes: Vec<[f32; 4]> = dets_low.iter().map(|d| d.tlwh).collect();
-        let (matches_low, u_track_low, _) =
-            iou_match(&r_boxes, &low_boxes, self.second_match_thresh);
-
-        // `r_tracked` only holds Tracked-state tracks, so a second-stage match is
-        // always a plain update (never a re-activation).
-        for (local, idet) in matches_low {
-            let itrack = r_tracked[local];
-            let det = &dets_low[idet];
-            pool[itrack].update(det, self.frame_id, &self.kalman_filter);
-            activated.push(pool[itrack].clone());
-        }
-
-        // Tracked leftovers from the second stage become Lost.
-        for &local in &u_track_low {
-            let itrack = r_tracked[local];
-            if pool[itrack].state != TrackState::Lost {
-                pool[itrack].state = TrackState::Lost;
-                lost.push(pool[itrack].clone());
-            }
-        }
-
-        // Unmatched high detections above det_thresh start new tracks.
-        for &idet in &u_det_high {
-            let det = &dets_high[idet];
-            if det.score < self.det_thresh {
-                continue;
-            }
-            let mut track = BotTrack::from_detection(det, &self.kalman_filter);
-            track.activate(self.frame_id, self.next_id);
-            self.next_id += 1;
-            activated.push(track);
-        }
-
-        // Keep already-lost tracks (unmatched this frame) alive until they exceed
-        // the buffer. Tracks that just became lost in the second stage are already
-        // in `lost`, so restrict this to the originally-lost part of the pool.
-        for &i in &u_track {
-            if i >= n_tracked && self.frame_id - pool[i].frame_id <= self.buffer_size {
-                lost.push(pool[i].clone());
-            }
-        }
+        let outcome = byte_cascade::run(
+            pool,
+            n_tracked,
+            &dets_high,
+            &dets_low,
+            &cost,
+            self.match_thresh,
+            self.second_match_thresh,
+            self.det_thresh,
+            self.buffer_size,
+            self.frame_id,
+            &self.kalman_filter,
+            &mut self.next_id,
+        );
 
         // Commit the frame state.
-        self.tracked_stracks = activated;
-        self.tracked_stracks.extend(refind);
-        self.lost_stracks = lost;
+        self.tracked_stracks = outcome.activated;
+        self.tracked_stracks.extend(outcome.refind);
+        self.lost_stracks = outcome.lost;
 
         self.tracked_stracks
             .iter()

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("README.md")]
 
+use crate::trackers::common::byte_cascade::{self, CascadeDet, CascadeTrack};
 use crate::trackers::common::{CommonParams, KalmanTrack};
 use crate::utils::geometry::tlwh_to_xyah;
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, StateVector};
@@ -106,6 +107,46 @@ impl STrack {
             self.kalman.mean[7] = 0.0; // Clear velocity h if not tracked
         }
         self.tlwh = self.kalman.predict(kf); // Update box estimate
+    }
+}
+
+impl CascadeDet for STrack {
+    fn det_box(&self) -> [f32; 4] {
+        self.tlwh
+    }
+    fn det_score(&self) -> f32 {
+        self.score
+    }
+}
+
+impl CascadeTrack for STrack {
+    type Det = STrack;
+
+    fn is_tracked(&self) -> bool {
+        self.state == TrackState::Tracked
+    }
+    fn is_lost(&self) -> bool {
+        self.state == TrackState::Lost
+    }
+    fn set_lost(&mut self) {
+        self.state = TrackState::Lost;
+    }
+    fn cascade_frame_id(&self) -> usize {
+        self.frame_id
+    }
+    fn cascade_tlwh(&self) -> [f32; 4] {
+        self.tlwh
+    }
+    fn update_matched(&mut self, det: &STrack, frame_id: usize, kf: &KalmanFilter) {
+        self.update(det.clone(), frame_id, kf);
+    }
+    fn reactivate_matched(&mut self, det: &STrack, frame_id: usize, kf: &KalmanFilter) {
+        self.re_activate(det.clone(), frame_id, None, kf);
+    }
+    fn spawn(det: &STrack, frame_id: usize, track_id: u64, kf: &KalmanFilter) -> Self {
+        let mut track = det.clone();
+        track.activate(kf, frame_id, track_id);
+        track
     }
 }
 
@@ -244,134 +285,57 @@ impl ByteTrack {
     /// * `Vec<STrack>` - A list of active tracks in the current frame.
     pub fn update(&mut self, output_results: Vec<([f32; 4], f32, i64)>) -> Vec<STrack> {
         self.frame_id += 1;
-        let mut activated_stracks = Vec::new();
-        let mut refind_stracks = Vec::new();
-        let mut lost_stracks = Vec::new();
 
-        let detections: Vec<STrack> = output_results
-            .iter()
-            .map(|(tlwh, score, cls)| STrack::new(*tlwh, *score, *cls))
-            .collect();
-
+        // Split detections into high- and low-confidence sets.
         let mut detections_high = Vec::new();
         let mut detections_low = Vec::new();
-
-        for track in detections {
-            if track.score >= self.track_thresh {
-                detections_high.push(track);
+        for (tlwh, score, cls) in output_results {
+            let det = STrack::new(tlwh, score, cls);
+            if det.score >= self.track_thresh {
+                detections_high.push(det);
             } else {
-                detections_low.push(track);
+                detections_low.push(det);
             }
         }
 
-        // Predict
-        for track in &mut self.tracked_stracks {
+        // Predict every existing track forward.
+        for track in self
+            .tracked_stracks
+            .iter_mut()
+            .chain(&mut self.lost_stracks)
+        {
             track.predict(&self.kalman_filter);
         }
-        for track in &mut self.lost_stracks {
-            track.predict(&self.kalman_filter);
-        }
 
-        let mut unconfirmed = Vec::new();
-        let mut tracked_stracks = Vec::new();
-        for track in self.tracked_stracks.drain(..) {
-            if !track.is_activated {
-                unconfirmed.push(track);
-            } else {
-                tracked_stracks.push(track);
-            }
-        }
+        // Pool: tracked tracks first, then lost tracks.
+        let mut pool: Vec<STrack> = self.tracked_stracks.drain(..).collect();
+        let n_tracked = pool.len();
+        pool.append(&mut self.lost_stracks);
 
-        // Match High
-        let mut strack_pool = Vec::new();
-        strack_pool.extend_from_slice(&tracked_stracks);
-        strack_pool.extend_from_slice(&self.lost_stracks);
-
-        // First matching: high-confidence detections against tracked + lost tracks.
-        let pool_boxes: Vec<[f32; 4]> = strack_pool.iter().map(|s| s.tlwh).collect();
+        // ByteTrack's stage-one cost is the plain IoU distance.
+        let pool_boxes: Vec<[f32; 4]> = pool.iter().map(|s| s.tlwh).collect();
         let high_boxes: Vec<[f32; 4]> = detections_high.iter().map(|s| s.tlwh).collect();
-        let (matches, u_track, u_detection) =
-            crate::utils::assignment::iou_match(&pool_boxes, &high_boxes, self.match_thresh);
+        let cost = crate::utils::geometry::iou_cost_matrix(&pool_boxes, &high_boxes);
 
-        for (itrack, idet) in matches {
-            let track = &mut strack_pool[itrack];
-            let det = &detections_high[idet];
-            if track.state == TrackState::Tracked {
-                track.update(det.clone(), self.frame_id, &self.kalman_filter);
-                activated_stracks.push(track.clone());
-            } else {
-                track.re_activate(det.clone(), self.frame_id, None, &self.kalman_filter);
-                refind_stracks.push(track.clone());
-            }
-        }
-
-        // Second matching: low-confidence detections against the tracks that were
-        // still Tracked but left unmatched by the first round.
-        let mut r_tracked_stracks = Vec::new();
-        for &i in &u_track {
-            let track = &strack_pool[i];
-            if track.state == TrackState::Tracked {
-                r_tracked_stracks.push(track.clone());
-            }
-        }
-
-        // Second matching: low-confidence detections against still-tracked leftovers.
-        let r_tracked_boxes: Vec<[f32; 4]> = r_tracked_stracks.iter().map(|s| s.tlwh).collect();
-        let low_boxes: Vec<[f32; 4]> = detections_low.iter().map(|s| s.tlwh).collect();
-        let (matches, u_track_second, _) = crate::utils::assignment::iou_match(
-            &r_tracked_boxes,
-            &low_boxes,
+        let outcome = byte_cascade::run(
+            pool,
+            n_tracked,
+            &detections_high,
+            &detections_low,
+            &cost,
+            self.match_thresh,
             self.second_match_thresh,
+            self.det_thresh,
+            self.buffer_size,
+            self.frame_id,
+            &self.kalman_filter,
+            &mut self.next_id,
         );
 
-        for (itrack, idet) in matches {
-            let track = &mut r_tracked_stracks[itrack];
-            let det = &detections_low[idet];
-            if track.state == TrackState::Tracked {
-                track.update(det.clone(), self.frame_id, &self.kalman_filter);
-                activated_stracks.push(track.clone());
-            } else {
-                track.re_activate(det.clone(), self.frame_id, None, &self.kalman_filter);
-                refind_stracks.push(track.clone());
-            }
-        }
+        self.tracked_stracks = outcome.activated;
+        self.tracked_stracks.extend(outcome.refind);
+        self.lost_stracks = outcome.lost;
 
-        for &it in &u_track_second {
-            let track = &mut r_tracked_stracks[it];
-            if track.state != TrackState::Lost {
-                track.state = TrackState::Lost;
-                lost_stracks.push(track.clone());
-            }
-        }
-
-        // Unmatched high-confidence detections above det_thresh start new tracks.
-        for &i in &u_detection {
-            let det = &detections_high[i];
-            if det.score < self.det_thresh {
-                continue;
-            }
-            let mut new_track = det.clone();
-            let id = self.next_id;
-            self.next_id += 1;
-            new_track.activate(&self.kalman_filter, self.frame_id, id);
-            activated_stracks.push(new_track);
-        }
-
-        // Keep first-round lost tracks alive until they exceed the buffer.
-        for &i in &u_track {
-            let track = &strack_pool[i];
-            if track.state == TrackState::Lost && self.frame_id - track.frame_id <= self.buffer_size
-            {
-                lost_stracks.push(track.clone());
-            }
-        }
-
-        // Commit the frame state: matched and refound tracks are active, the rest lost.
-        self.tracked_stracks = activated_stracks;
-        self.tracked_stracks.extend(refind_stracks);
-        self.lost_stracks = lost_stracks;
-
-        // Output the activated tracks for this frame.
         self.tracked_stracks
             .iter()
             .filter(|t| t.is_activated)

--- a/src/trackers/common/byte_cascade.rs
+++ b/src/trackers/common/byte_cascade.rs
@@ -1,0 +1,152 @@
+//! Shared two-stage association cascade for the ByteTrack family.
+//!
+//! ByteTrack and BoT-SORT run the same cascade. High confidence detections are matched
+//! against the pool of tracked and lost tracks, low confidence detections then try to
+//! recover the still-tracked leftovers, unmatched high detections start new tracks, and
+//! originally-lost tracks are kept alive until they age out of the buffer.
+//!
+//! The only thing that differs between the two is the stage-one cost matrix. ByteTrack
+//! passes a plain IoU distance; BoT-SORT passes an appearance-fused cost. Camera motion
+//! is applied by BoT-SORT before the cascade runs. Everything else lives here once.
+
+use crate::utils::assignment::{greedy_match, iou_match};
+use crate::utils::kalman::KalmanFilter;
+
+/// A detection the cascade can read: its box and its score.
+pub(crate) trait CascadeDet {
+    /// The detection box in TLWH form.
+    fn det_box(&self) -> [f32; 4];
+    /// The detection confidence.
+    fn det_score(&self) -> f32;
+}
+
+/// A track the cascade can drive through the ByteTrack lifecycle.
+pub(crate) trait CascadeTrack: Sized + Clone {
+    /// The detection type this track is matched against.
+    type Det: CascadeDet;
+
+    /// Whether the track is currently in the tracked state.
+    fn is_tracked(&self) -> bool;
+    /// Whether the track is currently in the lost state.
+    fn is_lost(&self) -> bool;
+    /// Move the track into the lost state.
+    fn set_lost(&mut self);
+    /// Frame id of the track's most recent match.
+    fn cascade_frame_id(&self) -> usize;
+    /// Current box estimate in TLWH form.
+    fn cascade_tlwh(&self) -> [f32; 4];
+
+    /// Continue an already-tracked track with a matched detection.
+    fn update_matched(&mut self, det: &Self::Det, frame_id: usize, kf: &KalmanFilter);
+    /// Bring a lost track back with a matched detection, keeping its id.
+    fn reactivate_matched(&mut self, det: &Self::Det, frame_id: usize, kf: &KalmanFilter);
+    /// Create and activate a brand-new track from a detection.
+    fn spawn(det: &Self::Det, frame_id: usize, track_id: u64, kf: &KalmanFilter) -> Self;
+}
+
+/// The tracks produced by one cascade pass, ready for the caller to commit.
+pub(crate) struct CascadeOutcome<T> {
+    /// Tracks matched this frame or freshly spawned.
+    pub activated: Vec<T>,
+    /// Lost tracks recovered this frame.
+    pub refind: Vec<T>,
+    /// Tracks that are lost and still within the buffer.
+    pub lost: Vec<T>,
+}
+
+/// Run the two-stage cascade over a pool of tracks.
+///
+/// `pool` holds the tracked tracks first (`0..n_tracked`) then the lost tracks.
+/// `stage1_cost[i][j]` is the cost of pairing pool track `i` with high detection `j`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run<T: CascadeTrack>(
+    mut pool: Vec<T>,
+    n_tracked: usize,
+    high: &[T::Det],
+    low: &[T::Det],
+    stage1_cost: &[Vec<f32>],
+    match_thresh: f32,
+    second_match_thresh: f32,
+    det_thresh: f32,
+    buffer_size: usize,
+    frame_id: usize,
+    kf: &KalmanFilter,
+    next_id: &mut u64,
+) -> CascadeOutcome<T> {
+    let mut activated = Vec::new();
+    let mut refind = Vec::new();
+    let mut lost = Vec::new();
+
+    // Stage 1: high-confidence detections against the whole pool. Guard the empty case
+    // because greedy_match on an empty matrix cannot report the unmatched detections.
+    let (matches, u_track, u_det_high) = if pool.is_empty() || high.is_empty() {
+        (
+            Vec::new(),
+            (0..pool.len()).collect::<Vec<_>>(),
+            (0..high.len()).collect::<Vec<_>>(),
+        )
+    } else {
+        greedy_match(stage1_cost, match_thresh)
+    };
+
+    for (itrack, idet) in matches {
+        if pool[itrack].is_tracked() {
+            pool[itrack].update_matched(&high[idet], frame_id, kf);
+            activated.push(pool[itrack].clone());
+        } else {
+            pool[itrack].reactivate_matched(&high[idet], frame_id, kf);
+            refind.push(pool[itrack].clone());
+        }
+    }
+
+    // Stage 2: low-confidence detections against still-tracked leftovers, IoU only.
+    let r_tracked: Vec<usize> = u_track
+        .iter()
+        .copied()
+        .filter(|&i| pool[i].is_tracked())
+        .collect();
+    let r_boxes: Vec<[f32; 4]> = r_tracked.iter().map(|&i| pool[i].cascade_tlwh()).collect();
+    let low_boxes: Vec<[f32; 4]> = low.iter().map(|d| d.det_box()).collect();
+    let (matches_low, u_track_low, _) = iou_match(&r_boxes, &low_boxes, second_match_thresh);
+
+    for (local, idet) in matches_low {
+        let itrack = r_tracked[local];
+        pool[itrack].update_matched(&low[idet], frame_id, kf);
+        activated.push(pool[itrack].clone());
+    }
+
+    // Tracked leftovers from the second stage become lost.
+    for &local in &u_track_low {
+        let itrack = r_tracked[local];
+        if !pool[itrack].is_lost() {
+            pool[itrack].set_lost();
+            lost.push(pool[itrack].clone());
+        }
+    }
+
+    // Unmatched high detections above the init threshold start new tracks.
+    for &idet in &u_det_high {
+        if high[idet].det_score() < det_thresh {
+            continue;
+        }
+        let track = T::spawn(&high[idet], frame_id, *next_id, kf);
+        *next_id += 1;
+        activated.push(track);
+    }
+
+    // Keep originally-lost tracks that stayed unmatched alive until they exceed the
+    // buffer. Tracks that just became lost in stage two are already in `lost`, so this
+    // is restricted to the originally-lost part of the pool (indices at or past
+    // `n_tracked`).
+    for &i in &u_track {
+        if i >= n_tracked && frame_id - pool[i].cascade_frame_id() <= buffer_size {
+            lost.push(pool[i].clone());
+        }
+    }
+
+    CascadeOutcome {
+        activated,
+        refind,
+        lost,
+    }
+}

--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -6,6 +6,7 @@
 //! motion compensation transform.
 
 pub mod association;
+pub mod byte_cascade;
 pub mod cmc;
 pub mod obs_track;
 pub mod params;

--- a/tests/cascade_parity.rs
+++ b/tests/cascade_parity.rs
@@ -1,0 +1,73 @@
+//! Regression guard for the shared ByteTrack and BoT-SORT cascade.
+//!
+//! ByteTrack and BoT-SORT drive the same two-stage cascade; the only difference is the
+//! stage-one cost (plain IoU vs appearance-fused) and BoT-SORT's camera warp. With no
+//! embeddings and no camera motion, BoT-SORT reduces to ByteTrack, so both must produce
+//! identical output on a motion-only sequence. This test locks that in.
+
+use trackforge::trackers::botsort::BotSort;
+use trackforge::trackers::byte_track::ByteTrack;
+
+/// Deterministic sequence: object A steady, object B occluded on frames 4..7 and
+/// returning at low score on frame 7, object C entering at frame 2 and leaving after 9.
+fn sequence() -> Vec<Vec<([f32; 4], f32, i64)>> {
+    let mut frames = Vec::new();
+    for f in 0..14 {
+        let mut dets = Vec::new();
+        dets.push(([10.0 + f as f32 * 6.0, 40.0, 40.0, 90.0], 0.92, 0));
+        if !(4..7).contains(&f) {
+            let score = if f == 7 { 0.45 } else { 0.88 };
+            dets.push(([200.0 + f as f32 * 4.0, 60.0, 45.0, 95.0], score, 0));
+        }
+        if (2..10).contains(&f) {
+            dets.push(([400.0 - f as f32 * 5.0, 120.0, 38.0, 80.0], 0.8, 1));
+        }
+        frames.push(dets);
+    }
+    frames
+}
+
+fn ids(mut rows: Vec<u64>) -> Vec<u64> {
+    rows.sort_unstable();
+    rows
+}
+
+#[test]
+fn bytetrack_and_botsort_agree_on_motion_only() {
+    let mut byte = ByteTrack::new(0.5, 30, 0.8, 0.6);
+    let mut bot = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+    for (f, dets) in sequence().into_iter().enumerate() {
+        let mut b: Vec<_> = byte
+            .update(dets.clone())
+            .into_iter()
+            .map(|t| (t.track_id, t.tlwh, (t.score * 100.0) as i32))
+            .collect();
+        let mut o: Vec<_> = bot
+            .update(dets, &[])
+            .into_iter()
+            .map(|t| (t.track_id, t.tlwh, (t.score * 100.0) as i32))
+            .collect();
+        b.sort_by_key(|r| r.0);
+        o.sort_by_key(|r| r.0);
+        assert_eq!(b, o, "ByteTrack and BoT-SORT diverged on frame {f}");
+    }
+}
+
+#[test]
+fn occluded_object_keeps_its_id_after_the_gap() {
+    let mut byte = ByteTrack::new(0.5, 30, 0.8, 0.6);
+    let mut per_frame: Vec<Vec<u64>> = Vec::new();
+    for dets in sequence() {
+        per_frame.push(byte.update(dets).into_iter().map(|t| t.track_id).collect());
+    }
+    // Frame 0 establishes objects A (id 1) and B (id 2).
+    assert_eq!(ids(per_frame[0].clone()), vec![1, 2]);
+    // Object B is gone during the occlusion window.
+    assert!(!per_frame[5].contains(&2));
+    // Object B returns at high score on frame 8 and recovers its original id.
+    assert!(
+        per_frame[8].contains(&2),
+        "id 2 should recover after the gap"
+    );
+}


### PR DESCRIPTION
## What this does

ByteTrack and BoT-SORT ran the same two-stage association cascade with the bodies duplicated. This extracts it into `common::byte_cascade`, driven through a `CascadeTrack` and `CascadeDet` trait pair, so the logic lives in one place.

The only real difference between the two is the stage-one cost matrix. ByteTrack passes a plain IoU distance, BoT-SORT passes its appearance-fused cost and warps predictions by camera motion before the cascade runs. Both pass their cost into the shared `run`.

## Verification

`tests/cascade_parity.rs` drives a deterministic sequence with an occlusion through both trackers and asserts they produce identical output on motion only, and that an occluded object recovers its id after the gap. A golden snapshot captured before the refactor matched the output after it byte for byte.
