### PR TITLE
docs: update docs site for six trackers and fix markdownlint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,14 +17,14 @@
 </p>
 
 **Trackforge** is a unified, high-performance multi-object tracking library written in Rust and
-exposed to Python via PyO3. It implements four production-ready tracking algorithms on top of a
+exposed to Python via PyO3. It implements six production-ready tracking algorithms on top of a
 shared Kalman filter, so you can swap trackers without changing your integration code.
 
 ## Features
 
 - **High Performance** — Native Rust implementation; ByteTrack runs in under 1 ms/frame on typical hardware.
 - **Python Bindings** — Install from PyPI, import, and track in three lines.
-- **Four Algorithms** — SORT, ByteTrack, OC-SORT, and DeepSORT cover the full speed-accuracy spectrum.
+- **Six Algorithms** — SORT, ByteTrack, OC-SORT, DeepSORT, Deep OC-SORT, and BoT-SORT cover the full speed-accuracy spectrum.
 - **Unified API** — All trackers accept `(tlwh, score, class_id)` detection tuples.
 
 ## Installation
@@ -52,16 +52,18 @@ maturin develop --features python
 
 ## Choosing a Tracker
 
-| Tracker       | Appearance       | Matching             | When to use                                                 |
-| ------------- | ---------------- | -------------------- | ----------------------------------------------------------- |
-| **SORT**      | None             | IoU                  | Simple scenes, highest speed, no occlusions                 |
-| **ByteTrack** | None             | IoU (2-stage)        | Crowded scenes, low-confidence detections, short occlusions |
-| **OC-SORT**   | None             | IoU + velocity (OCM) | Scenes with frequent brief occlusions, no Re-ID available   |
-| **DeepSORT**  | Re-ID embeddings | Appearance + IoU     | Long occlusions, dense crowds, identity-sensitive use cases |
+| Tracker          | Appearance       | Matching                         | When to use                                                 |
+| ---------------- | ---------------- | -------------------------------- | ----------------------------------------------------------- |
+| **SORT**         | None             | IoU                              | Simple scenes, highest speed, no occlusions                 |
+| **ByteTrack**    | None             | IoU (2-stage)                    | Crowded scenes, low-confidence detections, short occlusions |
+| **OC-SORT**      | None             | IoU + velocity (OCM)             | Scenes with frequent brief occlusions, no Re-ID available   |
+| **DeepSORT**     | Re-ID embeddings | Appearance + IoU                 | Long occlusions, dense crowds, identity-sensitive use cases |
+| **Deep OC-SORT** | Re-ID embeddings | IoU + velocity + appearance      | Occlusions where OC-SORT motion plus Re-ID helps            |
+| **BoT-SORT**     | Re-ID embeddings | IoU + appearance + camera motion | Moving cameras, panning and zoom, with optional Re-ID       |
 
 All trackers share the same detection input format:
 
-```
+```text
 (tlwh: [f32; 4], score: f32, class_id: i64)
 ```
 
@@ -83,7 +85,7 @@ overlap.
 | `min_hits`      | `usize` | `3`     | Consecutive matched frames required before a track is confirmed |
 | `iou_threshold` | `f32`   | `0.3`   | Minimum IoU required to associate a detection with a track      |
 
-**Tuning tips**
+#### Tuning tips
 
 - Increase `max_age` to bridge short occlusions (at the cost of more false tracks).
 - Decrease `iou_threshold` when objects are densely packed (more permissive matching).
@@ -138,14 +140,15 @@ recall improvement over SORT with minimal added cost.
 
 ### Configuration
 
-| Parameter      | Type    | Default | Description                                                         |
-| -------------- | ------- | ------- | ------------------------------------------------------------------- |
-| `track_thresh` | `f32`   | `0.5`   | Confidence threshold separating high- and low-confidence detections |
-| `track_buffer` | `usize` | `30`    | Frames a lost track is buffered before deletion                     |
-| `match_thresh` | `f32`   | `0.8`   | IoU threshold for stage-1 (high-confidence) matching                |
-| `det_thresh`   | `f32`   | `0.6`   | Minimum confidence to initialise a new track                        |
+| Parameter             | Type    | Default | Description                                                         |
+| --------------------- | ------- | ------- | ------------------------------------------------------------------- |
+| `track_thresh`        | `f32`   | `0.5`   | Confidence threshold separating high- and low-confidence detections |
+| `track_buffer`        | `usize` | `30`    | Frames a lost track is buffered before deletion                     |
+| `match_thresh`        | `f32`   | `0.8`   | Stage-1 match cutoff as a maximum IoU distance (lower is stricter)  |
+| `det_thresh`          | `f32`   | `0.6`   | Minimum confidence to initialise a new track                        |
+| `second_match_thresh` | `f32`   | `0.5`   | Stage-2 match cutoff for recovering low-confidence detections       |
 
-**Tuning tips**
+#### Tuning tips
 
 - Lower `track_thresh` (e.g. `0.3`) to include more low-confidence detections in stage 2.
 - Increase `track_buffer` (e.g. `60`) when your detector produces intermittent misses.
@@ -219,7 +222,7 @@ common but Re-ID is unavailable.
 | `delta_t`       | `usize` | `3`     | Observation window (frames) used to compute velocity for OCV         |
 | `inertia`       | `f32`   | `0.2`   | Weight for the direction-consistency cost bonus during OCM (0.0-1.0) |
 
-**Tuning tips**
+#### Tuning tips
 
 - Increase `max_age` (e.g. `60`) when objects undergo long occlusions.
 - Increase `delta_t` for smoother velocity at the cost of responsiveness to rapid direction changes.
@@ -287,7 +290,7 @@ to IoU matching. Provides robust long-term identity maintenance.
 | `max_cosine_distance` | `f32`   | `0.2`   | Cosine distance threshold for appearance matching               |
 | `nn_budget`           | `usize` | `100`   | Maximum number of appearance embeddings stored per track (FIFO) |
 
-**Tuning tips**
+#### Tuning tips
 
 - Lower `max_cosine_distance` (e.g. `0.15`) for stricter Re-ID — reduces ID switches at the cost
   of more unmatched detections.
@@ -377,7 +380,7 @@ for t in &tracks {
 
 All trackers use the same detection tuple format:
 
-```
+```text
 ([x, y, w, h], score, class_id)
 ```
 

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -6,7 +6,7 @@
     <a href="https://pypi.org/project/trackforge/"><img src="https://img.shields.io/pypi/pyversions/trackforge?logo=python&logoColor=white" alt="Python versions" /></a>
 </p>
 
-Trackforge exposes four tracker classes. All are importable directly from the `trackforge`
+Trackforge exposes six tracker classes. All are importable directly from the `trackforge`
 module after installing with `pip install trackforge`.
 
 ```python
@@ -17,6 +17,8 @@ trackforge.BYTETRACK
 trackforge.SORT
 trackforge.OCSORT
 trackforge.DEEPSORT
+trackforge.DEEPOCSORT
+trackforge.BOTSORT
 ```
 
 ---
@@ -30,19 +32,21 @@ lost tracks using low-confidence detections.
 
 ```python
 trackforge.BYTETRACK(
-    track_thresh: float = 0.5,
-    track_buffer: int   = 30,
-    match_thresh: float = 0.8,
-    det_thresh: float   = 0.6,
+    track_thresh: float        = 0.5,
+    track_buffer: int          = 30,
+    match_thresh: float        = 0.8,
+    det_thresh: float          = 0.6,
+    second_match_thresh: float = 0.5,
 )
 ```
 
-| Parameter      | Type    | Default | Description                                                          |
-| -------------- | ------- | ------- | -------------------------------------------------------------------- |
-| `track_thresh` | `float` | `0.5`   | Confidence threshold that splits high- and low-confidence detections |
-| `track_buffer` | `int`   | `30`    | Frames a lost track is kept alive before deletion                    |
-| `match_thresh` | `float` | `0.8`   | IoU threshold for stage-1 (high-confidence) matching                 |
-| `det_thresh`   | `float` | `0.6`   | Minimum confidence to initialise a new track                         |
+| Parameter             | Type    | Default | Description                                                          |
+| --------------------- | ------- | ------- | -------------------------------------------------------------------- |
+| `track_thresh`        | `float` | `0.5`   | Confidence threshold that splits high- and low-confidence detections |
+| `track_buffer`        | `int`   | `30`    | Frames a lost track is kept alive before deletion                    |
+| `match_thresh`        | `float` | `0.8`   | Stage-1 match cutoff as a maximum IoU distance (lower is stricter)   |
+| `det_thresh`          | `float` | `0.6`   | Minimum confidence to initialise a new track                         |
+| `second_match_thresh` | `float` | `0.5`   | Stage-2 match cutoff for recovering low-confidence detections        |
 
 ### `update`
 
@@ -50,11 +54,11 @@ trackforge.BYTETRACK(
 tracks = tracker.update(detections: list[tuple[list[float], float, int]]) -> list[tuple]
 ```
 
-**Parameters**
+#### Parameters
 
 - `detections` — list of `([x, y, w, h], score, class_id)` tuples.
 
-**Returns**
+#### Returns
 
 A list of `(track_id, tlwh, score, class_id)` tuples for every active confirmed track in the
 current frame.
@@ -229,13 +233,13 @@ tracks = tracker.update(
 ) -> list[tuple[int, list[float], float, int]]
 ```
 
-**Parameters**
+#### Parameters
 
 - `detections` — list of `([x, y, w, h], score, class_id)` tuples.
 - `embeddings` — list of appearance embedding vectors, one per detection. Length must equal
   `len(detections)`. Each embedding can be any length but must be consistent within a session.
 
-**Returns**
+#### Returns
 
 A list of `(track_id, tlwh, score, class_id)` tuples for confirmed tracks matched in the current
 frame. Same format as all other trackers.
@@ -266,6 +270,100 @@ tracks = tracker.update(detections, embeddings)
 for track_id, tlwh, score, class_id in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
+
+---
+
+## `DEEPOCSORT`
+
+Deep OC-SORT. OC-SORT plus an appearance term, so it accepts embeddings and, optionally, a per-frame camera motion transform. Pass an empty embeddings list to track on motion only.
+
+### Constructor
+
+```python
+trackforge.DEEPOCSORT(
+    max_age: int               = 30,
+    min_hits: int              = 3,
+    iou_threshold: float       = 0.3,
+    delta_t: int               = 3,
+    inertia: float             = 0.2,
+    appearance_weight: float   = 0.5,
+    max_cosine_distance: float = 0.2,
+    nn_budget: int             = 100,
+)
+```
+
+| Parameter             | Type    | Default | Description                                                  |
+| --------------------- | ------- | ------- | ------------------------------------------------------------ |
+| `max_age`             | `int`   | `30`    | Frames a lost track survives before deletion                 |
+| `min_hits`            | `int`   | `3`     | Consecutive matched frames required to confirm a track       |
+| `iou_threshold`       | `float` | `0.3`   | Minimum IoU to associate a detection with a track            |
+| `delta_t`             | `int`   | `3`     | Frames back used to estimate an object's direction of travel |
+| `inertia`             | `float` | `0.2`   | How strongly that direction is trusted, range 0.0 to 1.0     |
+| `appearance_weight`   | `float` | `0.5`   | How much appearance counts against motion, range 0.0 to 1.0  |
+| `max_cosine_distance` | `float` | `0.2`   | Cosine distance gate for appearance matching                 |
+| `nn_budget`           | `int`   | `100`   | Maximum embeddings stored per track                          |
+
+### `update`
+
+```python
+tracks = tracker.update(
+    detections: list[tuple[list[float], float, int]],
+    embeddings: list[list[float]] = [],
+    camera_motion: list[float] | None = None,
+) -> list[tuple[int, list[float], float, int]]
+```
+
+#### Parameters
+
+- `detections` — list of `([x, y, w, h], score, class_id)` tuples.
+- `embeddings` — appearance vectors, one per detection, or an empty list for motion only.
+- `camera_motion` — six affine coefficients `[a, b, tx, c, d, ty]` mapping the previous frame to the current one, or `None` for a static camera.
+
+#### Returns
+
+A list of `(track_id, tlwh, score, class_id)` tuples for confirmed tracks matched in the current frame.
+
+---
+
+## `BOTSORT`
+
+BoT-SORT. ByteTrack plus camera motion compensation and an optional appearance term. Pass an empty embeddings list to track on motion only.
+
+### Constructor
+
+```python
+trackforge.BOTSORT(
+    track_thresh: float        = 0.5,
+    track_buffer: int          = 30,
+    match_thresh: float        = 0.8,
+    det_thresh: float          = 0.6,
+    second_match_thresh: float = 0.5,
+    proximity_thresh: float    = 0.5,
+    appearance_thresh: float   = 0.25,
+)
+```
+
+| Parameter             | Type    | Default | Description                                                   |
+| --------------------- | ------- | ------- | ------------------------------------------------------------- |
+| `track_thresh`        | `float` | `0.5`   | Score above which a detection is high confidence              |
+| `track_buffer`        | `int`   | `30`    | Frames a lost track is kept alive                             |
+| `match_thresh`        | `float` | `0.8`   | Stage-1 match cutoff as a maximum IoU distance                |
+| `det_thresh`          | `float` | `0.6`   | Minimum score to start a new track                            |
+| `second_match_thresh` | `float` | `0.5`   | Stage-2 match cutoff for recovering low-confidence detections |
+| `proximity_thresh`    | `float` | `0.5`   | How much boxes must overlap before appearance is used         |
+| `appearance_thresh`   | `float` | `0.25`  | How close two embeddings must be for Re-ID to help the match  |
+
+### `update`
+
+```python
+tracks = tracker.update(
+    detections: list[tuple[list[float], float, int]],
+    embeddings: list[list[float]] = [],
+    camera_motion: list[float] | None = None,
+) -> list[tuple[int, list[float], float, int]]
+```
+
+Same input and output format as `DEEPOCSORT.update`.
 
 ---
 


### PR DESCRIPTION
Brings the docs site up to date with all six trackers, adds second_match_thresh, and clears the pre-existing markdownlint findings in docs/index.md and docs/reference/python.md.