### PR TITLE
fix: use mem::take to silence clippy drain-collect lint

### DIFF
--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -382,7 +382,7 @@ impl BotSort {
         // First stage: high-confidence detections against tracked + lost tracks,
         // matched on the appearance-fused cost. Tracks are activated on creation, so
         // pool[0..n_tracked] are the tracked tracks and the rest are lost.
-        let mut tracked: Vec<BotTrack> = self.tracked_stracks.drain(..).collect();
+        let mut tracked: Vec<BotTrack> = std::mem::take(&mut self.tracked_stracks);
         let n_tracked = tracked.len();
         let mut pool: Vec<BotTrack> = Vec::new();
         pool.append(&mut tracked);

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -308,7 +308,7 @@ impl ByteTrack {
         }
 
         // Pool: tracked tracks first, then lost tracks.
-        let mut pool: Vec<STrack> = self.tracked_stracks.drain(..).collect();
+        let mut pool: Vec<STrack> = std::mem::take(&mut self.tracked_stracks);
         let n_tracked = pool.len();
         pool.append(&mut self.lost_stracks);
 


### PR DESCRIPTION
Replaces `.drain(..).collect()` with `std::mem::take` at two sites. Rust 1.98 flags these with the `clippy::drain_collect` lint, which fails the CI Lint (fmt + clippy) job due to `-D warnings`. Semantically identical, avoids an extra allocation.