### PR TITLE
feat: add det_ind track-to-detection mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ name = "byte_track_demo"
 path = "examples/rust/byte_track_demo.rs"
 
 [[example]]
+name = "det_ind_demo"
+path = "examples/rust/det_ind_demo.rs"
+
+[[example]]
 name = "deepsort_ort"
 path = "examples/deepsort_ort.rs"
 required-features = ["advanced_examples"]

--- a/README.md
+++ b/README.md
@@ -109,9 +109,15 @@ detections = [
 
 tracks = tracker.update(detections)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
+
+**Result:** each element of `tracks` is a tuple
+`(track_id, tlwh, score, class_id, det_ind)`. `det_ind` is the index of the
+detection the track was last created from or matched to in the current frame's
+detection list (or `None` when the track was not matched that frame). Use it to
+map a track back to its detection and reuse the detection's Re-ID embedding.
 
 ### Python - DeepSORT
 
@@ -131,7 +137,7 @@ embeddings = [[0.1, 0.2, 0.3, ...]]  # appearance feature vectors
 
 tracks = tracker.update(detections, embeddings)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}, Score: {score}")
 ```
 
@@ -155,7 +161,7 @@ detections = [
 
 tracks = tracker.update(detections)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 
@@ -181,7 +187,7 @@ embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
 # Pass embeddings for appearance-aware tracking, or omit them for motion only.
 tracks = tracker.update(detections, embeddings)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 
@@ -209,7 +215,7 @@ tracks = tracker.update(detections, embeddings)
 # to the current one.
 tracks = tracker.update(detections, embeddings, [1.0, 0.0, 12.0, 0.0, 1.0, -4.0])
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 
@@ -225,7 +231,7 @@ detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 # Pass embeddings for appearance-aware tracking, or omit them for motion only.
 tracks = tracker.update(detections)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 

--- a/book/src/trackers/botsort.md
+++ b/book/src/trackers/botsort.md
@@ -25,7 +25,7 @@ tracker = BOTSORT(track_thresh=0.5, track_buffer=30, match_thresh=0.8, det_thres
 detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection; omit for motion only
 tracks = tracker.update(detections, embeddings)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 

--- a/book/src/trackers/deep_ocsort.md
+++ b/book/src/trackers/deep_ocsort.md
@@ -25,7 +25,7 @@ tracker = DEEPOCSORT(max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, inert
 detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 embeddings = [[0.1, 0.2, 0.3]]  # one appearance vector per detection
 tracks = tracker.update(detections, embeddings)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 

--- a/book/src/trackers/deepsort.md
+++ b/book/src/trackers/deepsort.md
@@ -44,7 +44,7 @@ tracker = DEEPSORT(max_age=70, n_init=3, max_iou_distance=0.7, max_cosine_distan
 detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 embeddings = [[0.1] * 128]  # one vector per detection, from your Re-ID model
 
-for track_id, tlwh, score, class_id in tracker.update(detections, embeddings):
+for track_id, tlwh, score, class_id, det_ind in tracker.update(detections, embeddings):
     print(track_id, tlwh)
 ```
 

--- a/book/src/trackers/tracktrack.md
+++ b/book/src/trackers/tracktrack.md
@@ -31,7 +31,7 @@ tracker = TRACKTRACK(det_thresh=0.6, match_thresh=0.7, track_buffer=30, min_hits
 
 detections = [([100.0, 100.0, 50.0, 100.0], 0.9, 0)]
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}")
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -89,7 +89,7 @@ def run_tracking(video_path="test_video.mp4", output_path="output_tracking.mp4")
 
         online_tracks = tracker.update(detections)
 
-        for track_id, tlwh, score, class_id in online_tracks:
+        for track_id, tlwh, score, class_id, det_ind in online_tracks:
             x1, y1, w, h = tlwh
             cv2.rectangle(frame, (int(x1), int(y1)), (int(x1 + w), int(y1 + h)), (0, 255, 0), 2)
             cv2.putText(

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,9 +109,15 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
+
+**Result:** each element of `tracks` is a tuple
+`(track_id, tlwh, score, class_id, det_ind)`. `det_ind` is the index of the
+detection the track was last created from or matched to in the current frame's
+detection list (or `None` when the track was not matched that frame); use it to
+map a track back to its detection and reuse the detection's Re-ID embedding.
 
 ### Rust
 
@@ -174,7 +180,7 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
 
@@ -250,7 +256,7 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
 
@@ -351,7 +357,7 @@ embeddings = [
 ]
 
 tracks = tracker.update(detections, embeddings)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
 

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -61,7 +61,7 @@ tracks = tracker.update(detections: list[tuple[list[float], float, int]]) -> lis
 
 #### Returns
 
-A list of `(track_id, tlwh, score, class_id)` tuples for every active confirmed track in the
+A list of `(track_id, tlwh, score, class_id, det_ind)` tuples for every active confirmed track in the
 current frame.
 
 | Field      | Type          | Description                                                      |
@@ -70,6 +70,7 @@ current frame.
 | `tlwh`     | `list[float]` | Bounding box `[top-left-x, top-left-y, width, height]` in pixels |
 | `score`    | `float`       | Detection confidence of the most recent match                    |
 | `class_id` | `int`         | Class label of the most recent match                             |
+| `det_ind`  | `int \| None` | Index of the detection this track was last created from or matched to in the frame's detection list, or `None` when the track was not matched that frame; lets you map a track back to its detection to reuse its Re-ID embedding |
 
 ### Example
 
@@ -89,7 +90,7 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}  class={class_id}")
 ```
 
@@ -135,7 +136,7 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}")
 ```
 
@@ -194,7 +195,7 @@ detections = [
 ]
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}  class={class_id}")
 ```
 
@@ -231,7 +232,7 @@ trackforge.DEEPSORT(
 tracks = tracker.update(
     detections: list[tuple[list[float], float, int]],
     embeddings: list[list[float]],
-) -> list[tuple[int, list[float], float, int]]
+) -> list[tuple[int, list[float], float, int, int | None]]
 ```
 
 #### Parameters
@@ -242,7 +243,7 @@ tracks = tracker.update(
 
 #### Returns
 
-A list of `(track_id, tlwh, score, class_id)` tuples for confirmed tracks matched in the current
+A list of `(track_id, tlwh, score, class_id, det_ind)` tuples for confirmed tracks matched in the current
 frame. Same format as all other trackers.
 
 ### Example
@@ -268,7 +269,7 @@ detections = [
 embeddings = [np.random.rand(128).tolist() for _ in detections]
 
 tracks = tracker.update(detections, embeddings)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID={track_id}  box={tlwh}  score={score:.2f}")
 ```
 
@@ -311,7 +312,7 @@ tracks = tracker.update(
     detections: list[tuple[list[float], float, int]],
     embeddings: list[list[float]] = [],
     camera_motion: list[float] | None = None,
-) -> list[tuple[int, list[float], float, int]]
+) -> list[tuple[int, list[float], float, int, int | None]]
 ```
 
 #### Parameters
@@ -322,7 +323,7 @@ tracks = tracker.update(
 
 #### Returns
 
-A list of `(track_id, tlwh, score, class_id)` tuples for confirmed tracks matched in the current frame.
+A list of `(track_id, tlwh, score, class_id, det_ind)` tuples for confirmed tracks matched in the current frame.
 
 ---
 
@@ -361,7 +362,7 @@ tracks = tracker.update(
     detections: list[tuple[list[float], float, int]],
     embeddings: list[list[float]] = [],
     camera_motion: list[float] | None = None,
-) -> list[tuple[int, list[float], float, int]]
+) -> list[tuple[int, list[float], float, int, int | None]]
 ```
 
 Same input and output format as `DEEPOCSORT.update`.
@@ -405,7 +406,7 @@ tracks = tracker.update(
     detections: list[tuple[list[float], float, int]],
     embeddings: list[list[float]] = [],
     camera_motion: list[float] | None = None,
-) -> list[tuple[int, list[float], float, int]]
+) -> list[tuple[int, list[float], float, int, int | None]]
 ```
 
 Same input and output format as `BOTSORT.update`.

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -64,12 +64,12 @@ tracks = tracker.update(detections: list[tuple[list[float], float, int]]) -> lis
 A list of `(track_id, tlwh, score, class_id, det_ind)` tuples for every active confirmed track in the
 current frame.
 
-| Field      | Type          | Description                                                      |
-| ---------- | ------------- | ---------------------------------------------------------------- |
-| `track_id` | `int`         | Unique, monotonically increasing track identifier                |
-| `tlwh`     | `list[float]` | Bounding box `[top-left-x, top-left-y, width, height]` in pixels |
-| `score`    | `float`       | Detection confidence of the most recent match                    |
-| `class_id` | `int`         | Class label of the most recent match                             |
+| Field      | Type          | Description                                                                                                                                                                                                                       |
+| ---------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `track_id` | `int`         | Unique, monotonically increasing track identifier                                                                                                                                                                                 |
+| `tlwh`     | `list[float]` | Bounding box `[top-left-x, top-left-y, width, height]` in pixels                                                                                                                                                                  |
+| `score`    | `float`       | Detection confidence of the most recent match                                                                                                                                                                                     |
+| `class_id` | `int`         | Class label of the most recent match                                                                                                                                                                                              |
 | `det_ind`  | `int \| None` | Index of the detection this track was last created from or matched to in the frame's detection list, or `None` when the track was not matched that frame; lets you map a track back to its detection to reuse its Re-ID embedding |
 
 ### Example

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -62,7 +62,7 @@ for box in results[0].boxes:
                        float(box.conf[0]), int(box.cls[0])))
 
 tracks = tracker.update(detections)
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID {track_id}: {tlwh}")
 ```
 
@@ -135,10 +135,11 @@ trackforge.DEEPOCSORT(max_age=30, min_hits=3, iou_threshold=0.3, delta_t=3, iner
 Every tracker returns a list of tuples:
 
 ```python
-(track_id, [x, y, w, h], score, class_id)
+(track_id, [x, y, w, h], score, class_id, det_ind)
 ```
 
 - `track_id`: unique integer identifier for the track
 - `[x, y, w, h]`: bounding box in TLWH format (top-left x, y, width, height)
 - `score`: detection confidence
 - `class_id`: object class id from the detector
+- `det_ind`: the index of the detection this track was last created from / matched to (int), or `None` if the track has no associated detection

--- a/examples/python/botsort_demo.py
+++ b/examples/python/botsort_demo.py
@@ -79,7 +79,7 @@ def run_tracking(video: str, output: str, model_path: str, use_reid: bool) -> No
         else:
             embeddings = []
         tracks = tracker.update(detections, embeddings)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/byte_track_demo.py
+++ b/examples/python/byte_track_demo.py
@@ -57,7 +57,7 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
 
         detections = yolo_detections(model, frame, classes=[0])
         tracks = tracker.update(detections)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/deep_ocsort_demo.py
+++ b/examples/python/deep_ocsort_demo.py
@@ -81,7 +81,7 @@ def run_tracking(video: str, output: str, model_path: str, use_reid: bool) -> No
         else:
             embeddings = []
         tracks = tracker.update(detections, embeddings)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/deepsort_demo.py
+++ b/examples/python/deepsort_demo.py
@@ -66,7 +66,7 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
             embedder, transform, frame, [d[0] for d in detections]
         )
         tracks = tracker.update(detections, embeddings)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/ocsort_demo.py
+++ b/examples/python/ocsort_demo.py
@@ -57,7 +57,7 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
 
         detections = yolo_detections(model, frame, classes=[0])
         tracks = tracker.update(detections)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/sort_rtdetr_demo.py
+++ b/examples/python/sort_rtdetr_demo.py
@@ -201,7 +201,7 @@ def run_tracking(video: str, output: str, model_name: str) -> None:
             model, processor, device, frame, info.width, info.height, 0.5, classes=[0]
         )
         tracks = tracker.update(detections)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             name = (
                 COCO_CLASSES[class_id]
                 if class_id < len(COCO_CLASSES)

--- a/examples/python/sort_yolo_demo.py
+++ b/examples/python/sort_yolo_demo.py
@@ -55,7 +55,7 @@ def run_tracking(video: str, output: str, model_path: str) -> None:
 
         detections = yolo_detections(model, frame, classes=[0])
         tracks = tracker.update(detections)
-        for track_id, tlwh, score, class_id in tracks:
+        for track_id, tlwh, score, class_id, det_ind in tracks:
             draw_track(
                 frame, track_id, tlwh, label_for(track_id, model.names[class_id], score)
             )

--- a/examples/python/tracker_comparison.py
+++ b/examples/python/tracker_comparison.py
@@ -66,13 +66,13 @@ def run_comparison(video: str, output: str, model_path: str) -> None:
         frame_bt, frame_sort = frame.copy(), frame.copy()
 
         bt_tracks = bytetrack.update(detections)
-        for track_id, tlwh, _, _ in bt_tracks:
+        for track_id, tlwh, _, _, _ in bt_tracks:
             draw_track(
                 frame_bt, track_id, tlwh, f"ID:{track_id}", color=BYTETRACK_COLOR
             )
 
         sort_tracks = sort.update(detections)
-        for track_id, tlwh, _, _ in sort_tracks:
+        for track_id, tlwh, _, _, _ in sort_tracks:
             draw_track(frame_sort, track_id, tlwh, f"ID:{track_id}", color=SORT_COLOR)
 
         draw_hud(frame_bt, f"ByteTrack | tracks {len(bt_tracks)}")

--- a/examples/rust/det_ind_demo.rs
+++ b/examples/rust/det_ind_demo.rs
@@ -1,0 +1,75 @@
+//! Usage example: mapping a track back to its source detection with `det_ind`.
+//!
+//! `det_ind` on every returned track tells you which detection in the current
+//! frame's input list the track came from. Combined with a per-detection Re-ID
+//! embedding, that lets you build a track-id -> embedding gallery for long-term
+//! tracking: for each track, pull `detections[track.det_ind]` and reuse the
+//! detection's appearance feature.
+//!
+//! Run with:  cargo run --example det_ind_demo
+
+use std::collections::HashMap;
+
+use trackforge::trackers::botsort::BotSort;
+
+fn norm(v: &[f32]) -> Vec<f32> {
+    let mag: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if mag > 1e-6 {
+        v.iter().map(|x| x / mag).collect()
+    } else {
+        v.to_vec()
+    }
+}
+
+fn main() {
+    let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+    // Two distinct identities (orthogonal Re-ID embeddings so they stay separate).
+    let id_a = norm(&[1.0, 0.0, 0.0, 0.0]);
+    let id_b = norm(&[0.0, 1.0, 0.0, 0.0]);
+
+    // Per-track Re-ID gallery built *from the detections* via `det_ind`.
+    let mut gallery: HashMap<u64, Vec<Vec<f32>>> = HashMap::new();
+
+    for frame in 0..10 {
+        // Current frame's detections: index = position in this vec.
+        let detections = vec![
+            ([100.0 + 5.0 * frame as f32, 100.0, 40.0, 80.0], 0.9, 0),
+            ([300.0 - 3.0 * frame as f32, 120.0, 40.0, 80.0], 0.9, 1),
+        ];
+        let embeddings = vec![id_a.clone(), id_b.clone()];
+
+        let tracks = tracker.update(detections.clone(), &embeddings);
+
+        for track in &tracks {
+            // `det_ind` maps this track back to its detection...
+            let dt = track.det_ind.expect("track already has a source detection");
+            let (src_box, _src_score, src_class) = &detections[dt];
+
+            // ...so we can reuse the detection's Re-ID feature (e.g. append it to a
+            // track-id gallery for long-term re-identification).
+            let feature = &embeddings[dt];
+            gallery
+                .entry(track.track_id)
+                .or_default()
+                .push(feature.clone());
+
+            println!(
+                "frame {frame:2} | track {} from det {dt} (class {}) at {:?} | emb[..2] = {:?} | gallery len {}",
+                track.track_id,
+                src_class,
+                src_box,
+                &feature[..2],
+                gallery[&track.track_id].len(),
+            );
+        }
+    }
+
+    // Each identity should have exactly one stable track id: the gallery lets you
+    // find it again later purely by appearance.
+    assert_eq!(gallery.len(), 2, "expected two distinct tracked identities");
+    println!(
+        "\nTwo stable track ids produced a per-id Re-ID gallery: {:?}",
+        gallery.keys().collect::<Vec<_>>()
+    );
+}

--- a/python/trackforge.pyi
+++ b/python/trackforge.pyi
@@ -24,7 +24,7 @@ class BYTETRACK:
     ]
 
     tracks = tracker.update(detections)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -39,7 +39,7 @@ class BYTETRACK:
     ) -> None: ...
     def update(
         self, output_results: List[Tuple[List[float], float, int]]
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class SORT:
     """
@@ -57,7 +57,7 @@ class SORT:
     ]
 
     tracks = tracker.update(detections)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -70,7 +70,7 @@ class SORT:
     ) -> None: ...
     def update(
         self, detections: List[Tuple[List[float], float, int]]
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class OCSORT:
     """
@@ -94,7 +94,7 @@ class OCSORT:
     ]
 
     tracks = tracker.update(detections)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -109,7 +109,7 @@ class OCSORT:
     ) -> None: ...
     def update(
         self, detections: List[Tuple[List[float], float, int]]
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class DEEPSORT:
     """
@@ -135,7 +135,7 @@ class DEEPSORT:
     embeddings = [np.random.rand(128).tolist()]
 
     tracks = tracker.update(detections, embeddings)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -152,7 +152,7 @@ class DEEPSORT:
         self,
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]],
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class DEEPOCSORT:
     """
@@ -184,7 +184,7 @@ class DEEPOCSORT:
     embeddings = [[0.1, 0.2, 0.3]]
 
     tracks = tracker.update(detections, embeddings)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -205,7 +205,7 @@ class DEEPOCSORT:
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]] = ...,
         camera_motion: Optional[List[float]] = ...,
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class BOTSORT:
     """
@@ -235,7 +235,7 @@ class BOTSORT:
     embeddings = [[0.1, 0.2, 0.3]]
 
     tracks = tracker.update(detections, embeddings)
-    for track_id, box, score, class_id in tracks:
+    for track_id, box, score, class_id, det_ind in tracks:
         print(f"Track ID: {track_id}, Box: {box}")
     ```
     """
@@ -255,7 +255,7 @@ class BOTSORT:
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]] = ...,
         camera_motion: Optional[List[float]] = ...,
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...
 
 class TRACKTRACK:
     def __init__(
@@ -274,4 +274,4 @@ class TRACKTRACK:
         detections: List[Tuple[List[float], float, int]],
         embeddings: List[List[float]] = ...,
         camera_motion: Optional[List[float]] = ...,
-    ) -> List[Tuple[int, List[float], float, int]]: ...
+    ) -> List[Tuple[int, List[float], float, int, Optional[int]]]: ...

--- a/src/trackers/botsort/README.md
+++ b/src/trackers/botsort/README.md
@@ -85,7 +85,7 @@ tracks = tracker.update(detections, embeddings)
 camera_motion = [1.0, 0.0, 12.0, 0.0, 1.0, -4.0]
 tracks = tracker.update(detections, embeddings, camera_motion)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 

--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -382,7 +382,7 @@ impl BotSort {
         // First stage: high-confidence detections against tracked + lost tracks,
         // matched on the appearance-fused cost. Tracks are activated on creation, so
         // pool[0..n_tracked] are the tracked tracks and the rest are lost.
-        let mut tracked: Vec<BotTrack> = self.tracked_stracks.drain(..).collect();
+        let mut tracked: Vec<BotTrack> = std::mem::take(&mut self.tracked_stracks);
         let n_tracked = tracked.len();
         let mut pool: Vec<BotTrack> = Vec::new();
         pool.append(&mut tracked);

--- a/src/trackers/botsort/mod.rs
+++ b/src/trackers/botsort/mod.rs
@@ -16,6 +16,7 @@ pub(crate) struct Detection {
     score: f32,
     class_id: i64,
     feature: Option<Vec<f32>>,
+    det_ind: Option<usize>,
 }
 
 /// A single tracked object managed by BoT-SORT.
@@ -43,6 +44,8 @@ pub struct BotTrack {
     pub start_frame: usize,
     /// Number of consecutive frames the track has been followed.
     pub tracklet_len: usize,
+    /// Index of the source detection in the frame's input list (when available).
+    pub det_ind: Option<usize>,
 
     kalman: KalmanTrack,
     smooth_feat: Option<Vec<f32>>,
@@ -62,6 +65,7 @@ impl BotTrack {
             frame_id: 0,
             start_frame: 0,
             tracklet_len: 0,
+            det_ind: det.det_ind,
             kalman,
             smooth_feat: det.feature.as_ref().map(|f| l2_normalize(f)),
         }
@@ -83,6 +87,7 @@ impl BotTrack {
         self.tlwh = det.tlwh;
         self.score = det.score;
         self.class_id = det.class_id;
+        self.det_ind = det.det_ind;
         self.state = TrackState::Tracked;
         self.is_activated = true;
         self.frame_id = frame_id;
@@ -358,6 +363,7 @@ impl BotSort {
                 score,
                 class_id,
                 feature,
+                det_ind: Some(i),
             };
             if det.score >= self.track_thresh {
                 dets_high.push(det);
@@ -566,7 +572,15 @@ impl PyBotSort {
             .update_with_camera_motion(detections, &embeddings, &cmc);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }
@@ -577,6 +591,26 @@ mod tests {
 
     fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
         ([x, y, w, h], s, 0)
+    }
+
+    #[test]
+    fn det_ind_reflects_input_detection_index() {
+        let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+        let out = tracker.update(
+            vec![
+                det(10.0, 10.0, 50.0, 100.0, 0.9),
+                det(400.0, 10.0, 50.0, 100.0, 0.9),
+            ],
+            &[],
+        );
+        assert_eq!(out.len(), 2);
+        let left = out.iter().find(|t| (t.tlwh[0] - 10.0).abs() < 1.0).unwrap();
+        let right = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -27,6 +27,8 @@ pub struct STrack {
     pub start_frame: usize,
     /// Length of the tracklet (number of frames tracked).
     pub tracklet_len: usize,
+    /// Index of the source detection in the frame's input list (when available).
+    pub det_ind: Option<usize>,
 
     /// Shared per-track Kalman state and predict/update mechanics.
     kalman: KalmanTrack,
@@ -52,6 +54,7 @@ impl STrack {
             frame_id: 0,
             start_frame: 0,
             tracklet_len: 0,
+            det_ind: None,
             kalman: KalmanTrack {
                 mean: StateVector::zeros(),
                 covariance: CovarianceMatrix::identity(),
@@ -85,6 +88,7 @@ impl STrack {
         self.tracklet_len = 0;
         self.score = new_track.score;
         self.tlwh = new_track.tlwh; // Use new detection box
+        self.det_ind = new_track.det_ind;
 
         if let Some(id) = new_track_id {
             self.track_id = id;
@@ -98,6 +102,7 @@ impl STrack {
         self.is_activated = true;
         self.score = new_track.score;
         self.tlwh = new_track.tlwh;
+        self.det_ind = new_track.det_ind;
 
         self.kalman.update(&tlwh_to_xyah(&new_track.tlwh), kf);
     }
@@ -289,8 +294,9 @@ impl ByteTrack {
         // Split detections into high- and low-confidence sets.
         let mut detections_high = Vec::new();
         let mut detections_low = Vec::new();
-        for (tlwh, score, cls) in output_results {
-            let det = STrack::new(tlwh, score, cls);
+        for (i, (tlwh, score, cls)) in output_results.into_iter().enumerate() {
+            let mut det = STrack::new(tlwh, score, cls);
+            det.det_ind = Some(i);
             if det.score >= self.track_thresh {
                 detections_high.push(det);
             } else {
@@ -420,7 +426,15 @@ impl PyByteTrack {
         let tracks = self.inner.update(output_results);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }
@@ -479,6 +493,24 @@ mod tests {
         let output2 = tracker.update(vec![d2]);
         assert_eq!(output2.len(), 1, "Expected 1 track, got {}", output2.len());
         assert_eq!(output2[0].track_id, id);
+    }
+
+    #[test]
+    fn det_ind_reflects_input_detection_index() {
+        let mut tracker = ByteTrack::new(0.5, 30, 0.8, 0.6);
+        // Two high-confidence, well-separated objects.
+        let out = tracker.update(vec![
+            ([10.0, 10.0, 50.0, 100.0], 0.9, 0),
+            ([400.0, 10.0, 50.0, 100.0], 0.9, 1),
+        ]);
+        assert_eq!(out.len(), 2);
+        let left = out.iter().find(|t| (t.tlwh[0] - 10.0).abs() < 1.0).unwrap();
+        let right = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/src/trackers/byte_track/mod.rs
+++ b/src/trackers/byte_track/mod.rs
@@ -308,7 +308,7 @@ impl ByteTrack {
         }
 
         // Pool: tracked tracks first, then lost tracks.
-        let mut pool: Vec<STrack> = self.tracked_stracks.drain(..).collect();
+        let mut pool: Vec<STrack> = std::mem::take(&mut self.tracked_stracks);
         let n_tracked = pool.len();
         pool.append(&mut self.lost_stracks);
 

--- a/src/trackers/common/mod.rs
+++ b/src/trackers/common/mod.rs
@@ -17,12 +17,14 @@ pub use params::CommonParams;
 
 use crate::utils::geometry::xyah_to_tlwh;
 
-/// A track as returned to Python: `(track_id, tlwh, score, class_id)`.
+/// A track as returned to Python: `(track_id, tlwh, score, class_id, det_ind)`.
 ///
-/// Every Python binding maps its confirmed tracks into this shape, so the type is
-/// shared here rather than redeclared per tracker.
+/// `det_ind` is the index of the detection this track was last created from or
+/// matched to in the current frame's detection list, or `None` when the track was
+/// coasted (not matched) that frame. It lets callers map a track back to its
+/// detection to, e.g., reuse the detection's Re-ID feature.
 #[cfg(feature = "python")]
-pub type PyTrackingResult = (u64, [f32; 4], f32, i64);
+pub type PyTrackingResult = (u64, [f32; 4], f32, i64, Option<i64>);
 use crate::utils::kalman::{CovarianceMatrix, KalmanFilter, MeasurementVector, StateVector};
 
 /// Lifecycle state of a track.

--- a/src/trackers/common/obs_track.rs
+++ b/src/trackers/common/obs_track.rs
@@ -35,6 +35,9 @@ pub struct ObsTrack {
     pub time_since_update: usize,
     /// Total frames since track creation.
     pub age: usize,
+    /// Index of the detection this track was most recently matched to (in the
+    /// current frame's detection list), or `None` when unmatched this frame.
+    pub det_ind: Option<usize>,
 
     kalman: KalmanTrack,
     // Bounded observation history (xyah, frame_id) in insertion order, used for OCM and ORU.
@@ -67,6 +70,7 @@ impl ObsTrack {
             hit_streak: 1,
             time_since_update: 0,
             age: 1,
+            det_ind: None,
             kalman,
             observations: vec![(xyah, frame_id)],
             pending_features: feature.into_iter().collect(),

--- a/src/trackers/deep_ocsort/README.md
+++ b/src/trackers/deep_ocsort/README.md
@@ -84,7 +84,7 @@ tracks = tracker.update(detections, embeddings)
 camera_motion = [1.0, 0.0, 12.0, 0.0, 1.0, -4.0]
 tracks = tracker.update(detections, embeddings, camera_motion)
 
-for track_id, tlwh, score, class_id in tracks:
+for track_id, tlwh, score, class_id, det_ind in tracks:
     print(f"ID: {track_id}, Box: {tlwh}")
 ```
 

--- a/src/trackers/deep_ocsort/python.rs
+++ b/src/trackers/deep_ocsort/python.rs
@@ -80,7 +80,15 @@ impl PyDeepOcSort {
             .update_with_camera_motion(&detections, &embeddings, &cmc);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }

--- a/src/trackers/deep_ocsort/tracker.rs
+++ b/src/trackers/deep_ocsort/tracker.rs
@@ -121,6 +121,7 @@ impl DeepOcSortTracker {
             track.update_kf(&xyah, &self.kf);
             track.push_observation(xyah, self.frame_count, self.delta_t + 1);
             track.record_match(det.tlwh, det.score, det.class_id);
+            track.det_ind = Some(*det_idx);
 
             if use_appearance {
                 track.push_feature(embeddings[*det_idx].clone());
@@ -130,7 +131,7 @@ impl DeepOcSortTracker {
         for det_idx in unmatched_dets {
             let det = &dets[det_idx];
             let feature = use_appearance.then(|| embeddings[det_idx].clone());
-            let track = DeepOcSortTrack::new(
+            let mut track = DeepOcSortTrack::new(
                 det.tlwh,
                 det.score,
                 det.class_id,
@@ -139,6 +140,7 @@ impl DeepOcSortTracker {
                 feature,
                 &self.kf,
             );
+            track.det_ind = Some(det_idx);
             self.next_id += 1;
             self.tracks.push(track);
         }

--- a/src/trackers/deepsort/python.rs
+++ b/src/trackers/deepsort/python.rs
@@ -68,7 +68,15 @@ impl PyDeepSort {
             .tracks
             .iter()
             .filter(|t| t.is_confirmed() && t.time_since_update == 0)
-            .map(|t| (t.track_id, t.to_tlwh(), t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.to_tlwh(),
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect();
 
         Ok(tracks)

--- a/src/trackers/deepsort/track.rs
+++ b/src/trackers/deepsort/track.rs
@@ -25,6 +25,8 @@ pub struct Track {
     pub score: f32,
     /// Appearance embeddings accumulated since the last metric-gallery flush.
     pub features: Vec<Vec<f32>>,
+    /// Index of the last detection this track was matched to (None if never matched).
+    pub det_ind: Option<usize>,
 
     n_init: usize,
     max_age: usize,
@@ -53,6 +55,7 @@ impl Track {
             state: TrackState::Tentative,
             score,
             features: vec![feature],
+            det_ind: None,
             n_init,
             max_age,
         }

--- a/src/trackers/deepsort/tracker.rs
+++ b/src/trackers/deepsort/tracker.rs
@@ -53,6 +53,7 @@ impl DeepSortTracker {
             let track = &mut self.tracks[track_idx];
             let meas = Track::tlwh_to_xyah(&[tlwh.x, tlwh.y, tlwh.width, tlwh.height]);
             track.update(&self.kf, &meas, score, class_id, embedding.clone());
+            track.det_ind = Some(detection_idx);
         }
 
         // Mark missed tracks
@@ -70,6 +71,9 @@ impl DeepSortTracker {
                 class_id,
                 embedding.clone(),
             );
+            if let Some(t) = self.tracks.last_mut() {
+                t.det_ind = Some(detection_idx);
+            }
         }
 
         // Remove deleted tracks
@@ -319,6 +323,31 @@ mod tests {
     fn create_tracker() -> DeepSortTracker {
         let metric = NearestNeighborDistanceMetric::new(Metric::Cosine, 0.3, Some(100));
         DeepSortTracker::new(metric, 30, 3, 0.7)
+    }
+
+    #[test]
+    fn det_ind_reflects_input_detection_index() {
+        let mut tracker = create_tracker();
+        let dets = vec![
+            (BoundingBox::new(100.0, 100.0, 50.0, 100.0), 0.9, 0),
+            (BoundingBox::new(400.0, 400.0, 50.0, 100.0), 0.9, 1),
+        ];
+        let embs = vec![vec![1.0; 128], vec![2.0; 128]];
+        tracker.predict();
+        tracker.update(&dets, &embs);
+        assert_eq!(tracker.tracks.len(), 2);
+        let left = tracker
+            .tracks
+            .iter()
+            .find(|t| (t.to_tlwh()[0] - 100.0).abs() < 1.0)
+            .unwrap();
+        let right = tracker
+            .tracks
+            .iter()
+            .find(|t| (t.to_tlwh()[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/src/trackers/ocsort/mod.rs
+++ b/src/trackers/ocsort/mod.rs
@@ -187,12 +187,13 @@ impl OcSort {
             track.update_kf(&xyah, &self.kf);
             track.push_observation(xyah, self.frame_count, self.delta_t + 1);
             track.record_match(det.tlwh, det.score, det.class_id);
+            track.det_ind = Some(*det_idx);
         }
 
         // 4. Initialise new tracks for unmatched detections.
         for det_idx in unmatched_dets {
             let det = &detections[det_idx];
-            let track = OcSortTrack::new(
+            let mut track = OcSortTrack::new(
                 det.tlwh,
                 det.score,
                 det.class_id,
@@ -201,6 +202,7 @@ impl OcSort {
                 None,
                 &self.kf,
             );
+            track.det_ind = Some(det_idx);
             self.next_id += 1;
             self.tracks.push(track);
         }
@@ -361,7 +363,15 @@ impl PyOcSort {
         let tracks = self.inner.update(detections);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }
@@ -373,6 +383,26 @@ mod tests {
 
     fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
         ([x, y, w, h], s, 0)
+    }
+
+    #[test]
+    fn det_ind_reflects_input_detection_index() {
+        let mut tracker = OcSort::new(30, 1, 0.3, 3, 0.2);
+        let out = tracker.update(vec![
+            det(100.0, 100.0, 50.0, 100.0, 0.9),
+            det(400.0, 400.0, 50.0, 100.0, 0.85),
+        ]);
+        assert_eq!(out.len(), 2);
+        let left = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 100.0).abs() < 1.0)
+            .unwrap();
+        let right = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/src/trackers/sort/mod.rs
+++ b/src/trackers/sort/mod.rs
@@ -57,6 +57,9 @@ pub struct SortTrack {
     pub time_since_update: usize,
     /// Total age of the track in frames.
     pub age: usize,
+    /// Index into the current frame's detections of the detection that most
+    /// recently created or updated this track. `None` if never matched.
+    pub det_ind: Option<usize>,
 
     // Kalman Filter state
     kalman: KalmanTrack,
@@ -83,6 +86,7 @@ impl SortTrack {
             hits: 1,
             time_since_update: 0,
             age: 1,
+            det_ind: None,
             kalman,
         }
     }
@@ -215,18 +219,20 @@ impl Sort {
         // Step 3: Update matched tracks with detections
         for (det_idx, trk_idx) in matches {
             self.tracks[trk_idx].update(&detections[det_idx], &self.kalman_filter);
+            self.tracks[trk_idx].det_ind = Some(det_idx);
         }
 
         // Step 4: Create new tracks for unmatched detections
         for det_idx in unmatched_dets {
             let det = &detections[det_idx];
-            let new_track = SortTrack::new(
+            let mut new_track = SortTrack::new(
                 det.tlwh,
                 det.score,
                 det.class_id,
                 &self.kalman_filter,
                 self.next_id,
             );
+            new_track.det_ind = Some(det_idx);
             self.next_id += 1;
             self.tracks.push(new_track);
         }
@@ -327,7 +333,15 @@ impl PySort {
         let tracks = self.inner.update(detections);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }
@@ -347,6 +361,47 @@ mod tests {
         assert_eq!(track.state, SortTrackState::Tentative);
         assert_eq!(track.hits, 1);
         assert_eq!(track.time_since_update, 0);
+    }
+
+    #[test]
+    fn det_ind_tracks_create_and_match_source() {
+        let mut tracker = Sort::new(1, 1, 0.3);
+
+        // Two well-separated objects. Track created from the second detection
+        // (index 1) must carry det_ind = Some(1).
+        let tracks = tracker.update(vec![
+            ([100.0, 100.0, 50.0, 100.0], 0.9, 0),
+            ([400.0, 400.0, 50.0, 100.0], 0.85, 1),
+        ]);
+        assert_eq!(tracks.len(), 2);
+        let left = tracks
+            .iter()
+            .find(|t| (t.tlwh[0] - 100.0).abs() < 1.0)
+            .unwrap();
+        let right = tracks
+            .iter()
+            .find(|t| (t.tlwh[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
+
+        // Next frame both objects move: each track is re-matched, so det_ind now
+        // points at the detection it matched this frame.
+        let tracks = tracker.update(vec![
+            ([105.0, 105.0, 50.0, 100.0], 0.9, 0),
+            ([405.0, 405.0, 50.0, 100.0], 0.85, 1),
+        ]);
+        assert_eq!(tracks.len(), 2);
+        let left = tracks
+            .iter()
+            .find(|t| (t.tlwh[0] - 105.0).abs() < 1.0)
+            .unwrap();
+        let right = tracks
+            .iter()
+            .find(|t| (t.tlwh[0] - 405.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/src/trackers/tracktrack/mod.rs
+++ b/src/trackers/tracktrack/mod.rs
@@ -89,6 +89,8 @@ pub struct Track {
     pub track_id: u64,
     /// Lifecycle state.
     pub state: TrackState,
+    /// Index of the last detection this track was matched to (None if never matched).
+    pub det_ind: Option<usize>,
 
     prev_score: f32,
     hits: usize,
@@ -105,6 +107,7 @@ impl Track {
             class_id: det.class_id,
             track_id,
             state: TrackState::New,
+            det_ind: None,
             prev_score: det.score,
             hits: 1,
             end_frame: frame_id,
@@ -388,6 +391,7 @@ impl TrackTrack {
         for (t, d) in m1 {
             let det = &dets[stage1_pool[d]];
             tracked_lost[t].update(det, &self.kalman_filter, self.frame_id, self.min_hits);
+            tracked_lost[t].det_ind = Some(stage1_pool[d]);
         }
         for t in u_tracks1 {
             tracked_lost[t].state = TrackState::Lost;
@@ -414,6 +418,7 @@ impl TrackTrack {
         for (t, d) in m2 {
             let det = &dets[high_left[d]];
             tentative[t].update(det, &self.kalman_filter, self.frame_id, self.min_hits);
+            tentative[t].det_ind = Some(high_left[d]);
         }
         for t in u_tracks2 {
             tentative[t].state = TrackState::Removed;
@@ -535,8 +540,9 @@ impl TrackTrack {
 
         for (idx, &d) in candidates.iter().enumerate() {
             if allow[idx] {
-                let track =
+                let mut track =
                     Track::from_det(&dets[d], &self.kalman_filter, self.frame_id, self.next_id);
+                track.det_ind = Some(d);
                 self.next_id += 1;
                 self.tracks.push(track);
             }
@@ -638,7 +644,15 @@ impl PyTrackTrack {
             .update_with_camera_motion(detections, &embeddings, &cmc);
         Ok(tracks
             .into_iter()
-            .map(|t| (t.track_id, t.tlwh, t.score, t.class_id))
+            .map(|t| {
+                (
+                    t.track_id,
+                    t.tlwh,
+                    t.score,
+                    t.class_id,
+                    t.det_ind.map(|i| i as i64),
+                )
+            })
             .collect())
     }
 }
@@ -668,6 +682,30 @@ mod tests {
 
     fn det(x: f32, y: f32, w: f32, h: f32, s: f32) -> ([f32; 4], f32, i64) {
         ([x, y, w, h], s, 0)
+    }
+
+    #[test]
+    fn det_ind_reflects_input_detection_index() {
+        let mut t = TrackTrack::new();
+        let frame = vec![
+            det(100.0, 100.0, 50.0, 100.0, 0.9),
+            det(400.0, 400.0, 50.0, 100.0, 0.9),
+        ];
+        for _ in 0..3 {
+            t.update(frame.clone(), &[]);
+        }
+        let out = t.update(frame, &[]);
+        assert_eq!(out.len(), 2);
+        let left = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 100.0).abs() < 1.0)
+            .unwrap();
+        let right = out
+            .iter()
+            .find(|t| (t.tlwh[0] - 400.0).abs() < 1.0)
+            .unwrap();
+        assert_eq!(left.det_ind, Some(0));
+        assert_eq!(right.det_ind, Some(1));
     }
 
     #[test]

--- a/tests/det_ind_reid.rs
+++ b/tests/det_ind_reid.rs
@@ -1,0 +1,155 @@
+//! Real end-to-end tests for the `det_ind` track-to-detection mapping.
+//!
+//! These simulate a multi-frame Re-ID pipeline: a moving scene with two visually
+//! distinct identities is fed to BoT-SORT with one appearance embedding per
+//! detection. For every output track we then recover its source embedding through
+//! `detections[track.det_ind]` and check the recovered embedding is consistent
+//! with the track's identity. This is exactly the use case from the issue:
+//! a long-term tracking / Re-ID database indexed by detection.
+
+use trackforge::trackers::botsort::BotSort;
+
+const DIM: usize = 8;
+
+/// L2-normalise a feature vector (Re-ID embeddings are compared on the unit sphere).
+fn norm(v: &[f32]) -> Vec<f32> {
+    let mag = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if mag > 1e-6 {
+        v.iter().map(|x| x / mag).collect()
+    } else {
+        v.to_vec()
+    }
+}
+
+/// Deterministic identity embeddings: object A and object B are orthogonal, so
+/// cosine similarity cleanly separates them.
+fn feat_a() -> Vec<f32> {
+    let mut f = vec![0.0; DIM];
+    f[0] = 1.0;
+    norm(&f)
+}
+fn feat_b() -> Vec<f32> {
+    let mut f = vec![0.0; DIM];
+    f[1] = 1.0;
+    norm(&f)
+}
+
+fn cos(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Which identity a recovered embedding belongs to (`true` = A, `false` = B).
+fn is_a(emb: &[f32]) -> bool {
+    cos(emb, &feat_a()) > cos(emb, &feat_b())
+}
+
+#[test]
+fn det_ind_gallery_is_consistent_across_frames() {
+    let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+    // Identity -> track ids that ever mapped to it via det_ind.
+    let mut ids_for_a: Vec<u64> = Vec::new();
+    let mut ids_for_b: Vec<u64> = Vec::new();
+
+    for f in 0..=20 {
+        // Two well-separated moving objects.
+        let a_tlwh = [100.0 + 5.0 * f as f32, 100.0 + 0.5 * f as f32, 40.0, 80.0];
+        let b_tlwh = [300.0 - 3.0 * f as f32, 120.0, 40.0, 80.0];
+        let detections = vec![(a_tlwh, 0.9, 0), (b_tlwh, 0.9, 1)];
+        let embeddings = vec![feat_a(), feat_b()];
+
+        let tracks = tracker.update(detections.clone(), &embeddings);
+
+        for t in &tracks {
+            let di = t.det_ind.expect("activated track must carry det_ind");
+            assert!(di < detections.len(), "det_ind {di} out of range");
+            let recovered = &embeddings[di];
+            // Every track's recovered embedding must belong to one consistent identity.
+            if is_a(recovered) {
+                ids_for_a.push(t.track_id);
+            } else {
+                ids_for_b.push(t.track_id);
+            }
+            // The recovered box must agree with the detection it claims to be.
+            let det_tlwh = &detections[di].0;
+            for k in 0..4 {
+                assert!(
+                    (det_tlwh[k] - t.tlwh[k]).abs() < 1.5,
+                    "track {:?} det_ind {di} box mismatch: {:?} vs {:?}",
+                    t.tlwh,
+                    det_tlwh,
+                    t.tlwh
+                );
+            }
+        }
+    }
+
+    // Both objects were tracked, so each identity saw at least one track.
+    assert!(!ids_for_a.is_empty(), "object A was never tracked");
+    assert!(!ids_for_b.is_empty(), "object B was never tracked");
+
+    // Stability: a single identity is never captured under multiple track ids
+    // (i.e. det_ind never points a track at the wrong object), and the two
+    // identities never share a track id.
+    ids_for_a.sort();
+    ids_for_b.sort();
+    ids_for_a.dedup();
+    ids_for_b.dedup();
+    assert_eq!(
+        ids_for_a.len(),
+        1,
+        "identity A mapped to multiple track ids: {ids_for_a:?}"
+    );
+    assert_eq!(
+        ids_for_b.len(),
+        1,
+        "identity B mapped to multiple track ids: {ids_for_b:?}"
+    );
+    assert_ne!(
+        ids_for_a[0], ids_for_b[0],
+        "identities A and B shared a track id"
+    );
+}
+
+#[test]
+fn det_ind_survives_reacquisition_after_occlusion() {
+    let mut tracker = BotSort::new(0.5, 30, 0.8, 0.6, 0.5, 0.25);
+
+    let hidden = |f: usize| (8..=10).contains(&f); // object B is occluded frames 8-10
+
+    let mut b_id_before: Option<u64> = None;
+    let mut b_id_after: Option<u64> = None;
+
+    for f in 0..=24 {
+        let a_tlwh = [100.0 + 4.0 * f as f32, 100.0, 40.0, 80.0];
+        let b_tlwh = [300.0 - 3.0 * f as f32, 120.0, 40.0, 80.0];
+
+        let mut detections = vec![(a_tlwh, 0.9, 0)];
+        let mut embeddings = vec![feat_a()];
+        if !hidden(f) {
+            detections.push((b_tlwh, 0.9, 1));
+            embeddings.push(feat_b());
+        }
+
+        for t in tracker.update(detections.clone(), &embeddings) {
+            let di = t.det_ind.expect("activated track must carry det_ind");
+            assert!(di < detections.len());
+            let recovered = &embeddings[di];
+            if !is_a(recovered) {
+                // This is object B's track.
+                if f < 8 && b_id_before.is_none() {
+                    b_id_before = Some(t.track_id);
+                }
+                if f > 12 && b_id_after.is_none() {
+                    b_id_after = Some(t.track_id);
+                }
+            }
+        }
+    }
+
+    // Object B must be tracked before and after the occlusion, and keep the same id
+    // (re-acquired through Re-ID), with det_ind pointing at its detection again.
+    let before = b_id_before.expect("B was never tracked before occlusion");
+    let after = b_id_after.expect("B was not re-tracked after occlusion");
+    assert_eq!(before, after, "B's track id changed across the occlusion");
+}

--- a/tests/python_det_ind_check.py
+++ b/tests/python_det_ind_check.py
@@ -1,0 +1,72 @@
+"""Real Python-side check of the `det_ind` feature (PR #160 / issue #156).
+
+Drives the native trackforge module from Python and verifies:
+  1. Every returned track is now a 5-tuple (track_id, tlwh, score, class_id, det_ind).
+  2. `det_ind` is an int (or None) and maps back into the same frame's detection list.
+  3. Building a per-track gallery via `detections[track.det_ind]` yields stable,
+     identity-consistent embeddings across frames (the Re-ID use case).
+
+Runs on pure stdlib only (no numpy). Usage:
+    python3 -m venv /tmp/tf_venv
+    /tmp/tf_venv/bin/pip install target/wheels/trackforge-*.whl
+    /tmp/tf_venv/bin/python tests/python_det_ind_check.py
+"""
+
+import math
+
+import trackforge
+
+
+def norm(v):
+    mag = math.sqrt(sum(x * x for x in v))
+    return [x / mag for x in v] if mag > 1e-6 else list(v)
+
+
+def dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+FEAT_A = norm([1.0, 0.0, 0.0, 0.0])  # identity A (dim 4)
+FEAT_B = norm([0.0, 1.0, 0.0, 0.0])  # identity B
+
+
+def check(tracker_cls, name, **kwargs):
+    tracker = tracker_cls(**kwargs)
+    gallery = {}  # track_id -> list of embeddings recovered via det_ind
+    ids_for_a, ids_for_b = set(), set()
+
+    for f in range(12):
+        dets = [
+            ([100.0 + 5.0 * f, 100.0, 40.0, 80.0], 0.9, 0),
+            ([300.0 - 3.0 * f, 120.0, 40.0, 80.0], 0.9, 1),
+        ]
+        embs = [FEAT_A, FEAT_B]
+        tracks = tracker.update(dets)
+        for t in tracks:
+            assert isinstance(t, tuple) and len(t) == 5, f"expected 5-tuple, got {t!r}"
+            tid, tlwh, score, cls, det_ind = t
+            assert det_ind is None or isinstance(det_ind, int), f"det_ind={det_ind!r}"
+            assert det_ind is not None, "activated track should carry det_ind"
+            assert 0 <= det_ind < len(dets), f"det_ind {det_ind} out of range"
+            src_box, _, _ = dets[det_ind]
+            src_emb = embs[det_ind]
+            for k in range(4):
+                assert abs(src_box[k] - tlwh[k]) < 1.5, f"box mismatch {src_box} vs {tlwh}"
+            # Embedding must belong to one consistent identity.
+            (ids_for_b if dot(src_emb, FEAT_B) > dot(src_emb, FEAT_A) else ids_for_a).add(tid)
+            gallery.setdefault(tid, []).append(tuple(src_emb))
+
+    assert ids_for_a and ids_for_b, f"{name}: one identity never tracked"
+    assert len(ids_for_a) == 1, f"{name}: identity A split across {sorted(ids_for_a)}"
+    assert len(ids_for_b) == 1, f"{name}: identity B split across {sorted(ids_for_b)}"
+    assert ids_for_a != ids_for_b, f"{name}: ids shared between identities"
+    print(f"[OK] {name}: det_ind present & consistent; "
+          f"A ids={sorted(ids_for_a)} B ids={sorted(ids_for_b)} gallery ids={sorted(gallery)}")
+
+
+if __name__ == "__main__":
+    check(trackforge.BYTETRACK, "BYTETRACK")
+    check(trackforge.BOTSORT, "BOTSORT", appearance_thresh=0.5)
+    check(trackforge.SORT, "SORT", min_hits=1)
+    check(trackforge.OCSORT, "OCSORT", min_hits=1)
+    print("ALL PYTHON det_ind CHECKS PASSED")

--- a/tests/python_det_ind_check.py
+++ b/tests/python_det_ind_check.py
@@ -51,17 +51,23 @@ def check(tracker_cls, name, **kwargs):
             src_box, _, _ = dets[det_ind]
             src_emb = embs[det_ind]
             for k in range(4):
-                assert abs(src_box[k] - tlwh[k]) < 1.5, f"box mismatch {src_box} vs {tlwh}"
+                assert abs(src_box[k] - tlwh[k]) < 1.5, (
+                    f"box mismatch {src_box} vs {tlwh}"
+                )
             # Embedding must belong to one consistent identity.
-            (ids_for_b if dot(src_emb, FEAT_B) > dot(src_emb, FEAT_A) else ids_for_a).add(tid)
+            (
+                ids_for_b if dot(src_emb, FEAT_B) > dot(src_emb, FEAT_A) else ids_for_a
+            ).add(tid)
             gallery.setdefault(tid, []).append(tuple(src_emb))
 
     assert ids_for_a and ids_for_b, f"{name}: one identity never tracked"
     assert len(ids_for_a) == 1, f"{name}: identity A split across {sorted(ids_for_a)}"
     assert len(ids_for_b) == 1, f"{name}: identity B split across {sorted(ids_for_b)}"
     assert ids_for_a != ids_for_b, f"{name}: ids shared between identities"
-    print(f"[OK] {name}: det_ind present & consistent; "
-          f"A ids={sorted(ids_for_a)} B ids={sorted(ids_for_b)} gallery ids={sorted(gallery)}")
+    print(
+        f"[OK] {name}: det_ind present & consistent; "
+        f"A ids={sorted(ids_for_a)} B ids={sorted(ids_for_b)} gallery ids={sorted(gallery)}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -29,10 +29,11 @@ def test_ocsort_update_returns_track():
     )
     tracks = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
     assert len(tracks) == 1
-    track_id, tlwh, score, class_id = tracks[0]
+    track_id, tlwh, score, class_id, det_ind = tracks[0]
     assert track_id == 1
     assert len(tlwh) == 4
     assert class_id == 0
+    assert det_ind == 0
 
 
 def test_ocsort_confirmed_after_min_hits():
@@ -182,9 +183,10 @@ def test_deepocsort_motion_only():
     t = trackforge.DEEPOCSORT(min_hits=1)
     tracks = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
     assert len(tracks) == 1
-    track_id, tlwh, score, class_id = tracks[0]
+    track_id, tlwh, score, class_id, det_ind = tracks[0]
     assert track_id == 1
     assert len(tlwh) == 4
+    assert det_ind == 0
 
 
 def test_deepocsort_with_embeddings_keeps_id():
@@ -241,9 +243,10 @@ def test_botsort_motion_only():
     t = trackforge.BOTSORT()
     tracks = t.update([([100.0, 100.0, 50.0, 100.0], 0.9, 0)])
     assert len(tracks) == 1
-    track_id, tlwh, score, class_id = tracks[0]
+    track_id, tlwh, score, class_id, det_ind = tracks[0]
     assert track_id == 1
     assert len(tlwh) == 4
+    assert det_ind == 0
 
 
 def test_botsort_with_embeddings_keeps_id():


### PR DESCRIPTION
Adds a public `det_ind: Option<usize>` to every tracker result so a track can be mapped back to the detection it was created from / matched to, letting callers reuse the detection's Re-ID feature for long-term re-identification.

Closes #156

What it does:
- Adds `det_ind` to all 7 trackers (SORT, ByteTrack, BoT-SORT, OC-SORT, Deep OC-SORT, DeepSORT, TrackTrack), wired at creation and on each match with the input detection index.
- Python bindings now return it as the 5th tuple element: (track_id, tlwh, score, class_id, det_ind) -> int | None (breaking tuple change).
- Adds per-tracker tests, real multi-frame Re-ID pipeline tests, and a Rust usage example (cargo run --example det_ind_demo).
- Fixes a CI-clippy memory lint (`drain_collect`) on stable 1.98 found while working in here.