### PR TITLE
chore(ruff): add lint config and bump the pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,9 @@ repos:
 
   # --- Python (pyo3 bindings / scripts) --------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.15.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/examples/python/reid.py
+++ b/examples/python/reid.py
@@ -17,9 +17,9 @@ from typing import Sequence
 import cv2
 import numpy as np
 import torch
-import torchvision.models as models
 import torchvision.transforms as T
 from PIL import Image
+from torchvision import models
 
 
 def get_embedder() -> tuple[torch.nn.Module, T.Compose]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,12 @@ classifiers = [
 [tool.maturin]
 features = ["python"]
 python-source = "python"
+
+[tool.ruff]
+src = ["python", "examples/python", "scripts"]
+
+[tool.ruff.lint]
+extend-select = ["I", "RUF022", "PLR0402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["trackforge"]

--- a/python/trackforge/trackforge.pyi
+++ b/python/trackforge/trackforge.pyi
@@ -1,12 +1,12 @@
 from typing import List, Optional, Tuple
 
 __all__ = [
-    "BYTETRACK",
-    "SORT",
-    "OCSORT",
-    "DEEPSORT",
-    "DEEPOCSORT",
     "BOTSORT",
+    "BYTETRACK",
+    "DEEPOCSORT",
+    "DEEPSORT",
+    "OCSORT",
+    "SORT",
     "TRACKTRACK",
 ]
 

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -1,8 +1,8 @@
 """Integration tests for the Python bindings — exercises Rust glue code."""
 
 import pytest
-import trackforge
 
+import trackforge
 
 # ---------------------------------------------------------------------------
 # OCSORT


### PR DESCRIPTION
Sets src so trackforge and common resolve as first party, enables import sorting, and moves the hook to the same ruff version as the CLI.